### PR TITLE
make pi-forall work on both: ghc 7.8.4 and 7.10.3, intial commit

### DIFF
--- a/full/README.md
+++ b/full/README.md
@@ -13,7 +13,7 @@ clarity, not for speed. The point of this implementation is an introduction to
 practical issues of language design and how specific features interact with
 each other. 
 
-Furthermore, this code base includes a number of features (unit, booleans,
+Furthermore, this code based includes a number of features (unit, booleans,
 sigma types) which are all subsumed by the general mechanism for
 datatypes. These are included to give examples before diving into the more
 general, and much more complicated, code. 
@@ -25,11 +25,11 @@ Features
   - bidirectional type checking
   - erased arguments (forall)
   - propositional equality 
-  - inductive & indexed datatypes 
+  - indexed datatypes 
 
 Not covered (Future work!)
 --------------------------
-  - nontermination
+  - termination & inductive datatypes
   - effects
   - co-induction
   - type inference & unification

--- a/full/pi-forall.cabal
+++ b/full/pi-forall.cabal
@@ -8,7 +8,7 @@ Author: Stephanie Weirich <sweirich@cis.upenn.edu>, based on code by Trellys Tea
 Maintainer: Stephanie Weirich <sweirich@cis.upenn.edu>
 Cabal-Version: >= 1.2
 Build-type: Simple
-tested-with: GHC == 7.6.3
+tested-with: GHC == 7.8.4, GHC == 7.10.3
 
 library
   hs-source-dirs: src/
@@ -22,20 +22,17 @@ executable pi-forall
   hs-source-dirs: src/
   Main-is: Main.hs
   Build-depends: base >=4,
-                 parsec >= 3.1 && < 3.1.5,
+                 parsec (>= 3.1 && < 3.1.5) || (>= 3.1.8 && < 3.2),
                  pretty >= 1.0.1.0,
-                 RepLib >= 0.5.3 && < 0.6, 
-                 unbound >= 0.4.2 && < 0.5,
-                 mtl,
-                 -- 0.2.2.0, 0.3.0.0
+                 unbound-generics >= 0.2,
+                 mtl >= 2.2.1,
                  transformers,
                  array >= 0.3.0.2 && < 0.6,
                  containers,
                  directory,
                  filepath,
                  HUnit,
-                 QuickCheck,
-                 bimap == 0.2.4
+                 QuickCheck
   Ghc-Options:  -Wall -fno-warn-unused-matches
 
 

--- a/full/src/Environment.hs
+++ b/full/src/Environment.hs
@@ -1,6 +1,6 @@
 {- OPLSS -}
 
-{-# LANGUAGE GADTs, NamedFieldPuns, FlexibleContexts, ViewPatterns, RankNTypes #-}
+{-# LANGUAGE GADTs, NamedFieldPuns, FlexibleContexts, ViewPatterns, RankNTypes, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches #-}
 
 -- | Utilities for managing a typechecking context.
@@ -21,13 +21,29 @@ module Environment
 import Syntax
 import PrettyPrint
 
-import Unbound.LocallyNameless hiding (Data)
+import Unbound.Generics.LocallyNameless
 
 import Text.PrettyPrint.HughesPJ
 import Text.ParserCombinators.Parsec.Pos(SourcePos)
 import Control.Monad.Reader
 import Control.Monad.Except
+
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Data.Monoid 
+#endif
+
+
+
+
 
 import Data.List
 import Data.Maybe (listToMaybe, catMaybes)

--- a/full/src/Equal.hs
+++ b/full/src/Equal.hs
@@ -1,6 +1,6 @@
 {- PiForall language, OPLSS -}
 
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE ViewPatterns, FlexibleContexts, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches #-}
 
 -- | Compare two terms for equality
@@ -12,9 +12,22 @@ module Equal (whnf, equate, ensurePi,
 import Syntax
 import Environment
 
-import Unbound.LocallyNameless hiding (Data, Refl)
+import Unbound.Generics.LocallyNameless
 import Control.Monad.Except (catchError, zipWithM, zipWithM_)
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Control.Applicative ((<$>))
+#endif
+
+
 
 
 -- | compare two expressions for equality

--- a/full/src/LayoutToken.hs
+++ b/full/src/LayoutToken.hs
@@ -18,7 +18,7 @@
 -- 
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE PolymorphicComponents, NoMonomorphismRestriction, KindSignatures  #-}
+{-# LANGUAGE PolymorphicComponents, NoMonomorphismRestriction, KindSignatures, FlexibleContexts  #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing -fno-warn-unused-do-bind -fno-warn-unused-matches #-}
 
 module LayoutToken
@@ -744,20 +744,20 @@ makeTokenParser languageDef open sep close
     layoutBegin = (symbol open)  <?> ("layout opening symbol ("++open++")")
    
     layout p stop =
-	   (do { try layoutBegin; xs <- sepBy p (symbol ";") 
-	       ; layoutEnd <?> "explicit layout closing brace"
-	       ; stop; return (xs)}) <|>
+           (do { try layoutBegin; xs <- sepBy p (symbol ";") 
+               ; layoutEnd <?> "explicit layout closing brace"
+               ; stop; return (xs)}) <|>
            (do { indent; xs <- align p stop; return xs})
            
     align p stop = ormore <|> zero
       where zero = do { stop; option "" layoutSep; undent; return []}
-	    ormore = do { x <- p
-	                ; whiteSpace
-	                ; (do { try layoutSep; xs <- align p stop; return (x:xs)}) <|>
-	                  (do { try layoutEnd; stop; return([x])}) <|>
-	                     -- removing indentation happens automatically
-	                     -- in function whiteSpace
-	                  (do { stop; undent; return ([x])})}
+            ormore = do { x <- p
+                        ; whiteSpace
+                        ; (do { try layoutSep; xs <- align p stop; return (x:xs)}) <|>
+                          (do { try layoutEnd; stop; return([x])}) <|>
+                             -- removing indentation happens automatically
+                             -- in function whiteSpace
+                          (do { stop; undent; return ([x])})}
   
     whiteSpace =
        do { (col1,_,_) <- getInfo
@@ -779,7 +779,7 @@ makeTokenParser languageDef open sep close
                                     rev (s:ss) xs = rev ss (s++xs)
                                 in adjust (col2,p:ps,[])
               (cs,p:ps,_,GT) -> return ()
-          }    	             
+          }                  
 getInfo :: forall (m :: * -> *) t t1.
                  Monad m =>
                  ParsecT t1 t m (Column, t, t1)

--- a/full/src/Modules.hs
+++ b/full/src/Modules.hs
@@ -1,6 +1,6 @@
 {- PiForall language, OPLSS -}
 
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-orphans #-}
 
 -- | Tools for working with multiple source files
@@ -10,7 +10,23 @@ import Syntax
 import Parser(parseModuleFile, parseModuleImports)
 
 import Text.ParserCombinators.Parsec.Error
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions
 import Control.Applicative 
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet
+import Control.Applicative
+#endif
+
+
+
+
 import Control.Monad.Except
 import Control.Monad.State.Lazy
 import System.FilePath

--- a/full/src/Parser.hs
+++ b/full/src/Parser.hs
@@ -1,6 +1,6 @@
 {- PiForall language, OPLSS -}
 
-{-# LANGUAGE PatternGuards, FlexibleInstances, FlexibleContexts, TupleSections, ExplicitForAll #-}
+{-# LANGUAGE PatternGuards, FlexibleInstances, FlexibleContexts, TupleSections, ExplicitForAll, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-orphans #-}
 
 -- | A parsec-based parser for the concrete syntax.
@@ -15,15 +15,34 @@ module Parser
 
 import Syntax hiding (moduleImports)
 
-import Unbound.LocallyNameless hiding (Data,Refl,Infix,join,name)
+import Unbound.Generics.LocallyNameless
 
 import Text.Parsec hiding (State,Empty)
 import Text.Parsec.Expr(Operator(..),Assoc(..),buildExpressionParser)
 import qualified LayoutToken as Token
 
 import Control.Monad.State.Lazy hiding (join)
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Control.Applicative ( (<$>), (<*>))
+#endif
+
+
+
+
+
 import Control.Monad.Except hiding (join)
+
+
+
 
 import Data.List
 import qualified Data.Set as S
@@ -158,7 +177,7 @@ trellysStyle = Token.LanguageDef
                 , Token.nestedComments = True
                 , Token.identStart     = letter
                 , Token.identLetter    = alphaNum <|> oneOf "_'"
-                , Token.opStart	       = oneOf ":!#$%&*+.,/<=>?@\\^|-"
+                , Token.opStart        = oneOf ":!#$%&*+.,/<=>?@\\^|-"
                 , Token.opLetter       = oneOf ":!#$%&*+.,/<=>?@\\^|-"
                 , Token.caseSensitive  = True
                 , Token.reservedNames =

--- a/full/test/Fin.pi
+++ b/full/test/Fin.pi
@@ -22,6 +22,15 @@ data Fin (n : Nat) : Type where
 -- x : Fin 1
 -- x = Zero [0]
 
+x0 : Fin 3
+x0 = Zero [2]
+
+x1 : Fin 3
+x1 = Succ [2] (Zero [1])
+
+x2 : Fin 3
+x2 = Succ [2] (Succ [1] (Zero [0]))
+
 toNat : [n : Nat] -> Fin n -> Nat
 toNat = \ [n] fn . 
   case fn of 

--- a/full/test/Lambda0.pi
+++ b/full/test/Lambda0.pi
@@ -1,0 +1,80 @@
+module Lambda0 where
+
+{- 
+   A Simple example of an environment-based interpreter for a small lambda calculus. 
+   This example could easily be written in vanilla Haskell or ML. 
+-}
+  
+
+import Nat     
+import List
+
+data Exp : Type where
+  Var of (Nat)           -- variables, represented with de Bruijn indices
+  App of (Exp)(Exp)      -- application
+  Lam of (Exp)           -- anonymous functions
+  Lit of (Nat)           -- natural number constants
+  If0 of (Exp)(Exp)(Exp) -- test for zero
+
+idfun : Exp   -- \ x -> x 
+idfun = Lam (Var 0)
+
+k : Exp   -- \x y -> x
+k = Lam (Lam (Var 1))
+
+s : Exp   -- \ x y z -> x z (y z) 
+s = Lam (Lam (Lam (App (App (Var 2) (Var 0)) (App (Var 1) (Var 0)))))
+
+
+-- The result of our interpreter
+
+data Val : Type where
+  Clos of (List Val)(Exp)  -- a closure: pair of an environment and an expression w/ a free variable
+  VNat of (Nat)            -- natural number value
+
+
+-- List index (subscript) operator, starting from 0.
+
+nth : [a : Type] -> List a -> Nat -> a
+nth = \[a] l n. case l of 
+  Nil -> TRUSTME -- "index too large"
+  Cons x xs -> case n of 
+    Zero -> x
+    Succ m -> nth [a] xs m
+    
+-- The interpreter itself    
+
+interp : List Val -> Exp -> Val
+interp = \ rho exp . case exp of 
+   Var x -> nth [Val] rho x 
+   App e1 e2 -> 
+      let v1 = interp rho e1 in
+      let v2 = interp rho e2 in 
+      case v1 of 
+        Clos rho' body -> 
+          interp (Cons v2 rho') body
+        VNat i -> TRUSTME  -- can't apply numbers
+   Lam e -> Clos rho e
+   Lit i -> VNat i
+   If0 e1 e2 e3 -> 
+      case (interp rho e1) of 
+        VNat x -> case x of 
+          Zero     -> interp rho e2
+          (Succ y) -> interp rho e3
+        Clos rho exp -> TRUSTME 
+
+t1 : interp Nil (App (Lam (Var 0)) (Lit 3)) = VNat 3
+t1 = refl
+
+t2 : interp Nil (If0 (Lit 1) (Lit 2) (Lit 3)) = VNat 3
+t2 = refl
+
+-- an "unbound variable" error
+
+e1 : interp Nil (App (Lam (Var 1)) (Lit 2)) = TRUSTME
+e1 = refl
+
+-- a run-time type error
+
+e2 : interp Nil (App (Lit 1) (Lit 2)) = TRUSTME
+e2 = refl

--- a/full/test/Lambda1.pi
+++ b/full/test/Lambda1.pi
@@ -1,0 +1,87 @@
+module Lambda where
+
+import Nat
+
+data Fin (n : Nat) : Type where
+  Zero of [m:Nat]       [n = Succ m]
+  Succ of [m:Nat](Fin m)[n = Succ m]
+
+x1 : Fin 3
+x1 = Succ [2] (Succ [1] (Zero [0]))
+
+x2 : Fin 3
+x2 = Succ [2] (Zero [1])
+
+x3 : Fin 3
+x3 = Zero [2]
+
+
+data Vec (A : Type) (n : Nat) : Type where
+  Nil  of                       [n = Zero] 
+  Cons of [m:Nat] (A) (Vec A m) [n = Succ m]
+
+
+nth : [a:Type] -> [n:Nat] -> Vec a n -> Fin n -> a
+nth = \[a][n] v f. case v of 
+   Cons [m'] x xs -> case f of 
+      Zero [m] -> x 
+      Succ [m] f' -> nth [a][m] xs f'
+   Nil -> case f of {}   -- all cases are impossible
+
+
+{-
+-- alternative definition of nth
+
+nth : [a:Type] -> [n:Nat] -> Vec a n -> Fin n -> a
+nth = \[a][n] v f. case f of 
+   Zero [m] -> case v of 
+           Cons [m'] x xs -> x 
+   Succ [m] f' -> case v of 
+           Cons [m'] x xs -> nth [a][m] xs f'
+-}
+
+
+data Exp (n : Nat) : Type where
+   Var of (Fin n)                -- variables, represented with de Bruijn indices
+   App of (Exp n) (Exp n)        -- application
+   Lam of (Exp (Succ n))         -- anonymous functions
+   Lit of (Nat)                  -- natural number constants
+   If0 of (Exp n)(Exp n)(Exp n)  -- test for zero
+
+data Val : Type where
+  Clos of [n:Nat] (Vec Val n) (Exp (Succ n))
+  VNat of (Nat)
+
+
+interp : [n:Nat] -> Vec Val n -> Exp n -> Val
+interp = \[n] rho e. 
+  case e of 
+    Var x     -> nth [Val] [n] rho x
+    App e1 e2 -> 
+       let v1 = interp [n] rho e1 in
+       let v2 = interp [n] rho e2 in
+       case v1 of        
+         Clos [m] rho' body -> 
+            interp [Succ m] (Cons [m] v2 rho') body 
+         VNat i -> TRUSTME
+    Lam e     -> Clos [n] rho e
+    Lit i     -> VNat i
+    If0 e1 e2 e3 -> 
+      case (interp [n] rho e1) of 
+        VNat x -> case x of 
+          Zero     -> interp [n] rho e2
+          (Succ y) -> interp [n] rho e3
+        Clos [m]  rho exp -> TRUSTME
+
+
+one : Fin 2
+one = Succ [1] (Zero [0])
+
+t1 : interp [0] Nil (App (Lam (Var (Zero[0]))) (Lit 3)) = VNat 3
+t1 = refl
+
+-- t2 : interp [0] Nil (App (Lam (Var one)) (Lit 2)) = TRUSTME
+-- t2 = refl
+
+t3 : interp [0] Nil (App (Lit 1) (Lit 2)) = TRUSTME
+t3 = refl

--- a/full/test/Lambda2.pi
+++ b/full/test/Lambda2.pi
@@ -1,0 +1,97 @@
+module Lambda where
+
+import Nat
+import Fin
+import Vec 
+
+{- This version also requires that the object language be statically typed. 
+   It eliminates all run-time errors from the expression. -}
+
+lookup : [a:Type] -> [n:Nat] -> Fin n -> Vec a n -> a
+lookup = \[a][n] f v. case f of 
+   Zero [m] -> case v of 
+           Cons [m'] x xs -> x 
+   Succ [m] f' -> case v of 
+              Cons [m'] x xs -> lookup [a][m] f' xs
+
+data Ty : Type where
+   TyFun of (Ty)(Ty)
+   TyNat 
+
+data List (a : Type) : Type where
+   Nil 
+   Cons of (a) (List a)
+
+data VarRef (n : List Ty) (t : Ty) : Type where
+   VZ of [ts : List Ty][n = Cons t ts]
+   VS of [ts : List Ty][u : Ty](VarRef ts t)[n = Cons u ts]
+
+-- a single variable in a context containing one variable
+
+x : VarRef (Cons TyNat Nil) TyNat
+x = VZ [Nil]
+
+-- two variables in a context containing two vars
+
+y1 : VarRef (Cons TyNat (Cons TyNat Nil)) TyNat
+y1 = VZ [Cons TyNat Nil]
+
+y2 : VarRef (Cons TyNat (Cons TyNat Nil)) TyNat
+y2 = VS [Cons TyNat Nil][TyNat](VZ [Nil])
+
+
+data Exp (n : List Ty) (t : Ty) : Type where
+   Var of (VarRef n t)
+   App of [t1:Ty] (Exp n (TyFun t1 t)) (Exp n t1)
+   Lam of [t1: Ty][t2:Ty](Exp (Cons t1 n) t2) [t = TyFun t1 t2]
+   Lit of (Nat)[t = TyNat]
+   If0 of (Exp n TyNat)(Exp n t)(Exp n t)
+
+data Env (val : Ty -> Type) (n : List Ty)  : Type where
+   Nil  of [n = Nil]
+   Cons of [t : Ty][ts : List Ty](val t)(Env val ts) [n = Cons t ts]
+
+data Val (t : Ty) : Type where
+   Clos of [n:List Ty][t1:Ty][t2:Ty] 
+               (Env (\t. Val t) n) (Exp (Cons t1 n) t2)[t = TyFun t1 t2]
+   VNat of (Nat)[t = TyNat]
+
+env : List Ty -> Type
+env = \u.  Env (\t. Val t) u
+
+nth : [n : List Ty] -> [t:Ty] -> env n -> VarRef n t -> Val t
+nth = \ [n][t] e var. case var of 
+   VZ [ts]       -> case e of 
+                      Cons [u][ts] v vs -> v
+   VS [ts][u] v' -> case e of 
+	              Cons [u][ts] v vs -> nth [ts][t] vs v'
+
+
+interp : [n:List Ty] -> [t:Ty] -> env n -> Exp n t -> Val t
+interp = \[n][t] rho exp. 
+  case exp of 
+    Var x          -> nth [n][t] rho x
+    App [t1] e1 e2 -> 
+      let v1 = interp [n][TyFun t1 t] rho e1 in
+      let v2 = interp [n][t1]         rho e2 in 
+      case v1 of
+        Clos [m][t1'][t2'] rho' body -> 
+          let rho'' = (Cons [t1][m] v2 rho' : env (Cons t1 m)) in 
+          interp [Cons t1 m][t2'] rho'' body
+
+    Lam [t1][t2] body -> Clos [n][t1][t2] rho body
+    Lit i          -> VNat i
+    If0 e1 e2 e3 -> case (interp [n][TyNat] rho e1) of 
+        VNat x -> case x of 
+          Zero     -> interp [n][t] rho e2
+          (Succ y) -> interp [n][t] rho e3
+
+
+t1 : interp [Nil][TyNat] Nil (App[TyNat] (Lam [TyNat][TyNat] (Var x)) (Lit 3)) = VNat 3
+t1 = refl
+
+-- t2 : interp [Nil][TyNat] Nil (App[TyNat] (Lam[TyNat][TyNat] (Var y1)) (Lit 2)) = TRUSTME
+-- t2 = refl
+
+-- t3 : interp [Nil][TyNat] Nil (App[TyNat] (Lit 1) (Lit 2)) = TRUSTME
+-- t3 = refl  

--- a/full/test/List.pi
+++ b/full/test/List.pi
@@ -1,0 +1,51 @@
+module List where
+
+import Nat
+
+data List (a : Type) : Type where
+  Nil  
+  Cons of (a) (List a)
+
+map : [a : Type] -> [b: Type] -> (a -> b) -> List a -> List b 
+map = \[a] [b] f xs . case xs of 
+  Nil -> Nil
+  Cons y ys -> Cons (f y) (map [a][b] f ys)
+  
+id : [a:Type] -> a -> a
+id = \[a] x . x  
+  
+
+f_cong2 : [a : Type]->[b : Type] -> (f : a -> b) -> (a1 : a) -> (a2 : a) -> (a1 = a2) -> f a1 = f a2
+f_cong2 = \[a][b] f a1 a2 pf . subst refl by pf
+
+-- A proof about map           
+map_id : [a:Type] -> (xs : List a) -> (map [a][a] (id[a]) xs = id [List a] xs)
+map_id = \[a] xs. case xs of 
+       Nil -> refl
+       Cons y ys -> 
+         let ih = map_id [a] ys in 
+         f_cong2 [List a][List a] (\ys. Cons y ys) (map[a][a](id[a])ys) (id [List a]ys) ih
+
+
+
+append : [a:Type] -> List a -> List a -> List a
+append = \[a] xs ys. case xs of 
+  Nil -> ys
+  Cons x xs' -> Cons x (append [a] xs' ys)
+
+
+filter : [a:Type] -> (a -> Bool) -> List a -> List a 
+filter = \[a] f xs . case xs of 
+  Nil -> Nil
+  Cons y ys -> if f y then Cons y (filter [a] f ys) else (filter [a] f ys)
+  
+length : [a : Type] -> List a -> Nat   
+length = \[a] xs . case xs of 
+  Nil -> 0
+  Cons y ys -> plus 1 (length [a] ys)
+  
+head : [a : Type] -> List a -> a 
+head = \[a] xs . case xs of 
+  Nil -> TRUSTME  -- cannot remove b/c of exhaustivity check
+  Cons y ys -> y
+  

--- a/full/test/Vec.pi
+++ b/full/test/Vec.pi
@@ -14,18 +14,8 @@ import Fin
 import Product
 
 data Vec (A : Type) (n : Nat) : Type where
-  Nil  of [n = Zero] 
-  Cons of [m:Nat][n = Succ m] (A) (Vec A m)
-
-data In (A:Type) (x:A) (n:Nat) (v:Vec A n) : Type where
-  Here  of [m:Nat][n = Succ m][xs : Vec A m] 
-           [v = Cons [m] x xs]
-  There of [m:Nat][n = Succ m][xs : Vec A m] 
-           [y:A][v = Cons [m] y xs]
-           (In A x m xs)
-
-singleton : [A:Type] -> A -> Vec A 1
-singleton = \[A] x. Cons [0] x Nil
+  Nil  of                       [n = Zero] 
+  Cons of [m:Nat] (A) (Vec A m) [n = Succ m]
 
 
 head : [A :Type] -> [n:Nat] -> Vec A (Succ n) -> A
@@ -115,6 +105,17 @@ foldr'' = \[A][B] m f n v .
       case v of 
         Cons [m2] x xs -> 
           f m1 x (foldr'' [A][B] m1 f n xs)
+          
+data In (A:Type) (x:A) (n:Nat) (v:Vec A n) : Type where
+  Here  of [m:Nat][n = Succ m][xs : Vec A m] 
+           [v = Cons [m] x xs]
+  There of [m:Nat][n = Succ m][xs : Vec A m] 
+           [y:A][v = Cons [m] y xs]
+           (In A x m xs)
+
+singleton : [A:Type] -> A -> Vec A 1
+singleton = \[A] x. Cons [0] x Nil
+          
 
 
 

--- a/master/Makefile
+++ b/master/Makefile
@@ -11,6 +11,8 @@ SOLNS=$(addprefix ../full/,$(SRCS)) $(addprefix ../full/test/, $(TESTS) Lec1.pi 
 STUBREGEX='BEGIN { undef $$/; } s/[\{][-]\s*?SOLN.*?STUBWITH(\s*\r?\n|\s)(.*?)\s*[-][\}]/$$2/sg' 
 SOLNREGEX='BEGIN { undef $$/; } s/[\{][-]\s*?SOLN\s*?[-][\}](\s*\r?\n|\s)(.*?)[\{][-]\s*STUBWITH(\s*\r?\n|\s)(.*?)\s*[-][\}]/$$2/sg'
 
+flags=
+
 all: version1 version2 full
 
 test : all
@@ -32,8 +34,13 @@ test_version2 : ../version2
 	../version2/dist/build/pi-forall/pi-forall ../version2/test/Hw2.pi
 	../version2/dist/build/pi-forall/pi-forall ../version2/test/NatChurch.pi
 
+# full: $(SOLNS) Makefile
+# 	cd ../full && cabal install --disable-documentation . 
+
+# --force-reinstalls needed only on debian testing / ghc 7.8.4
 full: $(SOLNS) Makefile
-	cd ../full && cabal install --disable-documentation . 
+	cd ../full && cabal install --disable-documentation $(flags) . 
+
 
 test_full: ../full
 	cd ../full/test && make
@@ -46,7 +53,7 @@ uninstall:
 	@echo You can find them with \`which pi-forall\`
 
 clean:
-	-rm -rf src/dist src/cabal-dev ../version1/ ../version2/ full/ dist/ 
+	-rm -rf src/dist src/cabal-dev ../version1/ ../version2/ ../full/ dist/ 
 
 test:
 	cd test && make

--- a/master/pi-forall.cabal
+++ b/master/pi-forall.cabal
@@ -8,7 +8,7 @@ Author: Stephanie Weirich <sweirich@cis.upenn.edu>, based on code by Trellys Tea
 Maintainer: Stephanie Weirich <sweirich@cis.upenn.edu>
 Cabal-Version: >= 1.2
 Build-type: Simple
-tested-with: GHC == 7.6.3
+tested-with: GHC == 7.8.4, GHC == 7.10.3
 
 library
   hs-source-dirs: src/
@@ -24,7 +24,7 @@ executable pi-forall
   Build-depends: base >=4,
                  parsec (>= 3.1 && < 3.1.5) || (>= 3.1.8 && < 3.2),
                  pretty >= 1.0.1.0,
-                 unbound-generics >= 0.1.2,
+                 unbound-generics >= 0.2,
                  mtl >= 2.2.1,
                  transformers,
                  array >= 0.3.0.2 && < 0.6,

--- a/master/src/Environment.hs
+++ b/master/src/Environment.hs
@@ -1,6 +1,6 @@
 {- OPLSS -}
 
-{-# LANGUAGE GADTs, NamedFieldPuns, FlexibleContexts, ViewPatterns, RankNTypes #-}
+{-# LANGUAGE GADTs, NamedFieldPuns, FlexibleContexts, ViewPatterns, RankNTypes, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches #-}
 
 -- | Utilities for managing a typechecking context.
@@ -28,7 +28,23 @@ import Text.PrettyPrint.HughesPJ
 import Text.ParserCombinators.Parsec.Pos(SourcePos)
 import Control.Monad.Reader
 import Control.Monad.Except
+
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Data.Monoid 
+#endif
+
+
+
+
 
 {- SOLN DATA -}
 import Data.List{- STUBWITH -}

--- a/master/src/Equal.hs
+++ b/master/src/Equal.hs
@@ -1,6 +1,6 @@
 {- PiForall language, OPLSS -}
 
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE ViewPatterns, FlexibleContexts, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches #-}
 
 -- | Compare two terms for equality
@@ -15,7 +15,20 @@ import Environment
 import Unbound.Generics.LocallyNameless
 {- SOLN DATA -}
 import Control.Monad.Except (catchError, zipWithM, zipWithM_)
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Control.Applicative ((<$>))
+#endif
+
+
 {- STUBWITH -}
 
 -- | compare two expressions for equality

--- a/master/src/LayoutToken.hs
+++ b/master/src/LayoutToken.hs
@@ -18,7 +18,7 @@
 -- 
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE PolymorphicComponents, NoMonomorphismRestriction, KindSignatures  #-}
+{-# LANGUAGE PolymorphicComponents, NoMonomorphismRestriction, KindSignatures, FlexibleContexts  #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing -fno-warn-unused-do-bind -fno-warn-unused-matches #-}
 
 module LayoutToken
@@ -744,20 +744,20 @@ makeTokenParser languageDef open sep close
     layoutBegin = (symbol open)  <?> ("layout opening symbol ("++open++")")
    
     layout p stop =
-	   (do { try layoutBegin; xs <- sepBy p (symbol ";") 
-	       ; layoutEnd <?> "explicit layout closing brace"
-	       ; stop; return (xs)}) <|>
+           (do { try layoutBegin; xs <- sepBy p (symbol ";") 
+               ; layoutEnd <?> "explicit layout closing brace"
+               ; stop; return (xs)}) <|>
            (do { indent; xs <- align p stop; return xs})
            
     align p stop = ormore <|> zero
       where zero = do { stop; option "" layoutSep; undent; return []}
-	    ormore = do { x <- p
-	                ; whiteSpace
-	                ; (do { try layoutSep; xs <- align p stop; return (x:xs)}) <|>
-	                  (do { try layoutEnd; stop; return([x])}) <|>
-	                     -- removing indentation happens automatically
-	                     -- in function whiteSpace
-	                  (do { stop; undent; return ([x])})}
+            ormore = do { x <- p
+                        ; whiteSpace
+                        ; (do { try layoutSep; xs <- align p stop; return (x:xs)}) <|>
+                          (do { try layoutEnd; stop; return([x])}) <|>
+                             -- removing indentation happens automatically
+                             -- in function whiteSpace
+                          (do { stop; undent; return ([x])})}
   
     whiteSpace =
        do { (col1,_,_) <- getInfo
@@ -779,7 +779,7 @@ makeTokenParser languageDef open sep close
                                     rev (s:ss) xs = rev ss (s++xs)
                                 in adjust (col2,p:ps,[])
               (cs,p:ps,_,GT) -> return ()
-          }    	             
+          }                  
 getInfo :: forall (m :: * -> *) t t1.
                  Monad m =>
                  ParsecT t1 t m (Column, t, t1)

--- a/master/src/Modules.hs
+++ b/master/src/Modules.hs
@@ -1,6 +1,6 @@
 {- PiForall language, OPLSS -}
 
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-orphans #-}
 
 -- | Tools for working with multiple source files
@@ -10,7 +10,23 @@ import Syntax
 import Parser(parseModuleFile, parseModuleImports)
 
 import Text.ParserCombinators.Parsec.Error
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions
 import Control.Applicative 
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet
+import Control.Applicative
+#endif
+
+
+
+
 import Control.Monad.Except
 {- SOLN DATA -}
 import Control.Monad.State.Lazy{- STUBWITH -}

--- a/master/src/Parser.hs
+++ b/master/src/Parser.hs
@@ -1,6 +1,6 @@
 {- PiForall language, OPLSS -}
 
-{-# LANGUAGE PatternGuards, FlexibleInstances, FlexibleContexts, TupleSections, ExplicitForAll #-}
+{-# LANGUAGE PatternGuards, FlexibleInstances, FlexibleContexts, TupleSections, ExplicitForAll, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-orphans #-}
 
 -- | A parsec-based parser for the concrete syntax.
@@ -22,8 +22,27 @@ import Text.Parsec.Expr(Operator(..),Assoc(..),buildExpressionParser)
 import qualified LayoutToken as Token
 
 import Control.Monad.State.Lazy hiding (join)
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Control.Applicative ( (<$>), (<*>))
+#endif
+
+
+
+
+
 import Control.Monad.Except hiding (join)
+
+
+
 
 import Data.List
 import qualified Data.Set as S
@@ -176,7 +195,7 @@ trellysStyle = Token.LanguageDef
                 , Token.nestedComments = True
                 , Token.identStart     = letter
                 , Token.identLetter    = alphaNum <|> oneOf "_'"
-                , Token.opStart	       = oneOf ":!#$%&*+.,/<=>?@\\^|-"
+                , Token.opStart        = oneOf ":!#$%&*+.,/<=>?@\\^|-"
                 , Token.opLetter       = oneOf ":!#$%&*+.,/<=>?@\\^|-"
                 , Token.caseSensitive  = True
                 , Token.reservedNames =

--- a/master/src/PrettyPrint.hs
+++ b/master/src/PrettyPrint.hs
@@ -1,8 +1,6 @@
 {- PiForall language, OPLSS -}
 
-{-# LANGUAGE TypeSynonymInstances,ExistentialQuantification,FlexibleInstances, UndecidableInstances, FlexibleContexts,
-             ViewPatterns, DefaultSignatures, GeneralizedNewtypeDeriving
- #-}
+{-# LANGUAGE TypeSynonymInstances,ExistentialQuantification,FlexibleInstances, UndecidableInstances, ViewPatterns, DefaultSignatures, GeneralizedNewtypeDeriving, FlexibleContexts, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-name-shadowing #-}
 
 -- | A Pretty Printer. 
@@ -19,7 +17,24 @@ import Control.Monad.Reader
 import Text.PrettyPrint as PP
 import Text.ParserCombinators.Parsec.Pos (SourcePos, sourceName, sourceLine, sourceColumn)
 import Text.ParserCombinators.Parsec.Error (ParseError)
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Control.Applicative (Applicative(..), (<$>), (<*>))
+#endif
+
+
+
+
+
+
 import qualified Data.Set as S
 
 -- | The 'Disp' class governs types which can be turned into 'Doc's

--- a/master/src/Syntax.hs
+++ b/master/src/Syntax.hs
@@ -8,18 +8,34 @@
              ViewPatterns, 
              EmptyDataDecls,
              DeriveGeneric,
-             DeriveDataTypeable
- #-}
+             DeriveDataTypeable,
+             CPP #-}
 
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-orphans #-}
+
+
 
 -- | The abstract syntax of the simple dependently typed language
 -- See comment at the top of 'Parser' for the concrete syntax
 
 module Syntax where
 
-import Control.Applicative (pure)
-import Data.Monoid (mempty)
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
+
+-- both needed only on even earlier ghc's
+-- import Control.Applicative (pure)
+-- import Data.Monoid (mempty)
+#endif
+
+
 import GHC.Generics (Generic)
 import Data.Typeable (Typeable)
 

--- a/master/src/TypeCheck.hs
+++ b/master/src/TypeCheck.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE ViewPatterns, TypeSynonymInstances, 
              ExistentialQuantification, NamedFieldPuns, 
              ParallelListComp, FlexibleContexts, ScopedTypeVariables, 
-             TupleSections, FlexibleInstances #-}
+             TupleSections, FlexibleInstances, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches #-}
 
 -- | The main routines for type-checking 
@@ -16,7 +16,22 @@ import Equal
 
 import Unbound.Generics.LocallyNameless
 import Unbound.Generics.LocallyNameless.Internal.Fold (toListOf)
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Control.Applicative 
+#endif
+
+
+
+
 import Control.Monad.Except
 import Text.PrettyPrint.HughesPJ
 import Data.Maybe

--- a/version1/README.md
+++ b/version1/README.md
@@ -25,11 +25,11 @@ Features
   - bidirectional type checking
   - erased arguments (forall)
   - propositional equality 
-  - inductive & indexed datatypes 
+  - indexed datatypes 
 
 Not covered (Future work!)
 --------------------------
-  - nontermination
+  - termination & inductive datatypes
   - effects
   - co-induction
   - type inference & unification

--- a/version1/pi-forall.cabal
+++ b/version1/pi-forall.cabal
@@ -8,7 +8,7 @@ Author: Stephanie Weirich <sweirich@cis.upenn.edu>, based on code by Trellys Tea
 Maintainer: Stephanie Weirich <sweirich@cis.upenn.edu>
 Cabal-Version: >= 1.2
 Build-type: Simple
-tested-with: GHC == 7.6.3
+tested-with: GHC == 7.8.4, GHC == 7.10.3
 
 library
   hs-source-dirs: src/
@@ -24,7 +24,7 @@ executable pi-forall
   Build-depends: base >=4,
                  parsec (>= 3.1 && < 3.1.5) || (>= 3.1.8 && < 3.2),
                  pretty >= 1.0.1.0,
-                 unbound-generics >= 0.1.2,
+                 unbound-generics >= 0.2,
                  mtl >= 2.2.1,
                  transformers,
                  array >= 0.3.0.2 && < 0.6,

--- a/version1/src/Environment.hs
+++ b/version1/src/Environment.hs
@@ -1,6 +1,6 @@
 {- OPLSS -}
 
-{-# LANGUAGE GADTs, NamedFieldPuns, FlexibleContexts, ViewPatterns, RankNTypes #-}
+{-# LANGUAGE GADTs, NamedFieldPuns, FlexibleContexts, ViewPatterns, RankNTypes, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches #-}
 
 -- | Utilities for managing a typechecking context.
@@ -27,7 +27,23 @@ import Text.PrettyPrint.HughesPJ
 import Text.ParserCombinators.Parsec.Pos(SourcePos)
 import Control.Monad.Reader
 import Control.Monad.Except
+
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Data.Monoid 
+#endif
+
+
+
+
 
 
 import Data.Maybe (listToMaybe, catMaybes)

--- a/version1/src/Equal.hs
+++ b/version1/src/Equal.hs
@@ -1,6 +1,6 @@
 {- PiForall language, OPLSS -}
 
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE ViewPatterns, FlexibleContexts, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches #-}
 
 -- | Compare two terms for equality

--- a/version1/src/LayoutToken.hs
+++ b/version1/src/LayoutToken.hs
@@ -18,7 +18,7 @@
 -- 
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE PolymorphicComponents, NoMonomorphismRestriction, KindSignatures  #-}
+{-# LANGUAGE PolymorphicComponents, NoMonomorphismRestriction, KindSignatures, FlexibleContexts  #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing -fno-warn-unused-do-bind -fno-warn-unused-matches #-}
 
 module LayoutToken
@@ -744,20 +744,20 @@ makeTokenParser languageDef open sep close
     layoutBegin = (symbol open)  <?> ("layout opening symbol ("++open++")")
    
     layout p stop =
-	   (do { try layoutBegin; xs <- sepBy p (symbol ";") 
-	       ; layoutEnd <?> "explicit layout closing brace"
-	       ; stop; return (xs)}) <|>
+           (do { try layoutBegin; xs <- sepBy p (symbol ";") 
+               ; layoutEnd <?> "explicit layout closing brace"
+               ; stop; return (xs)}) <|>
            (do { indent; xs <- align p stop; return xs})
            
     align p stop = ormore <|> zero
       where zero = do { stop; option "" layoutSep; undent; return []}
-	    ormore = do { x <- p
-	                ; whiteSpace
-	                ; (do { try layoutSep; xs <- align p stop; return (x:xs)}) <|>
-	                  (do { try layoutEnd; stop; return([x])}) <|>
-	                     -- removing indentation happens automatically
-	                     -- in function whiteSpace
-	                  (do { stop; undent; return ([x])})}
+            ormore = do { x <- p
+                        ; whiteSpace
+                        ; (do { try layoutSep; xs <- align p stop; return (x:xs)}) <|>
+                          (do { try layoutEnd; stop; return([x])}) <|>
+                             -- removing indentation happens automatically
+                             -- in function whiteSpace
+                          (do { stop; undent; return ([x])})}
   
     whiteSpace =
        do { (col1,_,_) <- getInfo
@@ -779,7 +779,7 @@ makeTokenParser languageDef open sep close
                                     rev (s:ss) xs = rev ss (s++xs)
                                 in adjust (col2,p:ps,[])
               (cs,p:ps,_,GT) -> return ()
-          }    	             
+          }                  
 getInfo :: forall (m :: * -> *) t t1.
                  Monad m =>
                  ParsecT t1 t m (Column, t, t1)

--- a/version1/src/Modules.hs
+++ b/version1/src/Modules.hs
@@ -1,6 +1,6 @@
 {- PiForall language, OPLSS -}
 
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-orphans #-}
 
 -- | Tools for working with multiple source files
@@ -10,7 +10,23 @@ import Syntax
 import Parser(parseModuleFile, parseModuleImports)
 
 import Text.ParserCombinators.Parsec.Error
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions
 import Control.Applicative 
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet
+import Control.Applicative
+#endif
+
+
+
+
 import Control.Monad.Except
 
 import System.FilePath

--- a/version1/src/Parser.hs
+++ b/version1/src/Parser.hs
@@ -1,6 +1,6 @@
 {- PiForall language, OPLSS -}
 
-{-# LANGUAGE PatternGuards, FlexibleInstances, FlexibleContexts, TupleSections, ExplicitForAll #-}
+{-# LANGUAGE PatternGuards, FlexibleInstances, FlexibleContexts, TupleSections, ExplicitForAll, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-orphans #-}
 
 -- | A parsec-based parser for the concrete syntax.
@@ -22,8 +22,27 @@ import Text.Parsec.Expr(Operator(..),Assoc(..),buildExpressionParser)
 import qualified LayoutToken as Token
 
 import Control.Monad.State.Lazy hiding (join)
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Control.Applicative ( (<$>), (<*>))
+#endif
+
+
+
+
+
 import Control.Monad.Except hiding (join)
+
+
+
 
 import Data.List
 import qualified Data.Set as S
@@ -130,7 +149,7 @@ trellysStyle = Token.LanguageDef
                 , Token.nestedComments = True
                 , Token.identStart     = letter
                 , Token.identLetter    = alphaNum <|> oneOf "_'"
-                , Token.opStart	       = oneOf ":!#$%&*+.,/<=>?@\\^|-"
+                , Token.opStart        = oneOf ":!#$%&*+.,/<=>?@\\^|-"
                 , Token.opLetter       = oneOf ":!#$%&*+.,/<=>?@\\^|-"
                 , Token.caseSensitive  = True
                 , Token.reservedNames =

--- a/version1/src/PrettyPrint.hs
+++ b/version1/src/PrettyPrint.hs
@@ -1,8 +1,6 @@
 {- PiForall language, OPLSS -}
 
-{-# LANGUAGE TypeSynonymInstances,ExistentialQuantification,FlexibleInstances, UndecidableInstances, FlexibleContexts,
-             ViewPatterns, DefaultSignatures, GeneralizedNewtypeDeriving
- #-}
+{-# LANGUAGE TypeSynonymInstances,ExistentialQuantification,FlexibleInstances, UndecidableInstances, ViewPatterns, DefaultSignatures, GeneralizedNewtypeDeriving, FlexibleContexts, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-name-shadowing #-}
 
 -- | A Pretty Printer. 
@@ -19,7 +17,24 @@ import Control.Monad.Reader
 import Text.PrettyPrint as PP
 import Text.ParserCombinators.Parsec.Pos (SourcePos, sourceName, sourceLine, sourceColumn)
 import Text.ParserCombinators.Parsec.Error (ParseError)
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Control.Applicative (Applicative(..), (<$>), (<*>))
+#endif
+
+
+
+
+
+
 import qualified Data.Set as S
 
 -- | The 'Disp' class governs types which can be turned into 'Doc's

--- a/version1/src/Syntax.hs
+++ b/version1/src/Syntax.hs
@@ -8,18 +8,34 @@
              ViewPatterns, 
              EmptyDataDecls,
              DeriveGeneric,
-             DeriveDataTypeable
- #-}
+             DeriveDataTypeable,
+             CPP #-}
 
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-orphans #-}
+
+
 
 -- | The abstract syntax of the simple dependently typed language
 -- See comment at the top of 'Parser' for the concrete syntax
 
 module Syntax where
 
-import Control.Applicative (pure)
-import Data.Monoid (mempty)
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
+
+-- both needed only on even earlier ghc's
+-- import Control.Applicative (pure)
+-- import Data.Monoid (mempty)
+#endif
+
+
 import GHC.Generics (Generic)
 import Data.Typeable (Typeable)
 

--- a/version1/src/TypeCheck.hs
+++ b/version1/src/TypeCheck.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE ViewPatterns, TypeSynonymInstances, 
              ExistentialQuantification, NamedFieldPuns, 
              ParallelListComp, FlexibleContexts, ScopedTypeVariables, 
-             TupleSections, FlexibleInstances #-}
+             TupleSections, FlexibleInstances, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches #-}
 
 -- | The main routines for type-checking 
@@ -16,7 +16,22 @@ import Equal
 
 import Unbound.Generics.LocallyNameless
 import Unbound.Generics.LocallyNameless.Internal.Fold (toListOf)
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Control.Applicative 
+#endif
+
+
+
+
 import Control.Monad.Except
 import Text.PrettyPrint.HughesPJ
 import Data.Maybe

--- a/version2/README.md
+++ b/version2/README.md
@@ -25,11 +25,11 @@ Features
   - bidirectional type checking
   - erased arguments (forall)
   - propositional equality 
-  - inductive & indexed datatypes 
+  - indexed datatypes 
 
 Not covered (Future work!)
 --------------------------
-  - nontermination
+  - termination & inductive datatypes
   - effects
   - co-induction
   - type inference & unification

--- a/version2/pi-forall.cabal
+++ b/version2/pi-forall.cabal
@@ -8,7 +8,7 @@ Author: Stephanie Weirich <sweirich@cis.upenn.edu>, based on code by Trellys Tea
 Maintainer: Stephanie Weirich <sweirich@cis.upenn.edu>
 Cabal-Version: >= 1.2
 Build-type: Simple
-tested-with: GHC == 7.6.3
+tested-with: GHC == 7.8.4, GHC == 7.10.3
 
 library
   hs-source-dirs: src/
@@ -24,7 +24,7 @@ executable pi-forall
   Build-depends: base >=4,
                  parsec (>= 3.1 && < 3.1.5) || (>= 3.1.8 && < 3.2),
                  pretty >= 1.0.1.0,
-                 unbound-generics >= 0.1.2,
+                 unbound-generics >= 0.2,
                  mtl >= 2.2.1,
                  transformers,
                  array >= 0.3.0.2 && < 0.6,

--- a/version2/src/Environment.hs
+++ b/version2/src/Environment.hs
@@ -1,6 +1,6 @@
 {- OPLSS -}
 
-{-# LANGUAGE GADTs, NamedFieldPuns, FlexibleContexts, ViewPatterns, RankNTypes #-}
+{-# LANGUAGE GADTs, NamedFieldPuns, FlexibleContexts, ViewPatterns, RankNTypes, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches #-}
 
 -- | Utilities for managing a typechecking context.
@@ -27,7 +27,23 @@ import Text.PrettyPrint.HughesPJ
 import Text.ParserCombinators.Parsec.Pos(SourcePos)
 import Control.Monad.Reader
 import Control.Monad.Except
+
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Data.Monoid 
+#endif
+
+
+
+
 
 
 import Data.Maybe (listToMaybe, catMaybes)

--- a/version2/src/Equal.hs
+++ b/version2/src/Equal.hs
@@ -1,6 +1,6 @@
 {- PiForall language, OPLSS -}
 
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE ViewPatterns, FlexibleContexts, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches #-}
 
 -- | Compare two terms for equality

--- a/version2/src/LayoutToken.hs
+++ b/version2/src/LayoutToken.hs
@@ -18,7 +18,7 @@
 -- 
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE PolymorphicComponents, NoMonomorphismRestriction, KindSignatures  #-}
+{-# LANGUAGE PolymorphicComponents, NoMonomorphismRestriction, KindSignatures, FlexibleContexts  #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing -fno-warn-unused-do-bind -fno-warn-unused-matches #-}
 
 module LayoutToken
@@ -744,20 +744,20 @@ makeTokenParser languageDef open sep close
     layoutBegin = (symbol open)  <?> ("layout opening symbol ("++open++")")
    
     layout p stop =
-	   (do { try layoutBegin; xs <- sepBy p (symbol ";") 
-	       ; layoutEnd <?> "explicit layout closing brace"
-	       ; stop; return (xs)}) <|>
+           (do { try layoutBegin; xs <- sepBy p (symbol ";") 
+               ; layoutEnd <?> "explicit layout closing brace"
+               ; stop; return (xs)}) <|>
            (do { indent; xs <- align p stop; return xs})
            
     align p stop = ormore <|> zero
       where zero = do { stop; option "" layoutSep; undent; return []}
-	    ormore = do { x <- p
-	                ; whiteSpace
-	                ; (do { try layoutSep; xs <- align p stop; return (x:xs)}) <|>
-	                  (do { try layoutEnd; stop; return([x])}) <|>
-	                     -- removing indentation happens automatically
-	                     -- in function whiteSpace
-	                  (do { stop; undent; return ([x])})}
+            ormore = do { x <- p
+                        ; whiteSpace
+                        ; (do { try layoutSep; xs <- align p stop; return (x:xs)}) <|>
+                          (do { try layoutEnd; stop; return([x])}) <|>
+                             -- removing indentation happens automatically
+                             -- in function whiteSpace
+                          (do { stop; undent; return ([x])})}
   
     whiteSpace =
        do { (col1,_,_) <- getInfo
@@ -779,7 +779,7 @@ makeTokenParser languageDef open sep close
                                     rev (s:ss) xs = rev ss (s++xs)
                                 in adjust (col2,p:ps,[])
               (cs,p:ps,_,GT) -> return ()
-          }    	             
+          }                  
 getInfo :: forall (m :: * -> *) t t1.
                  Monad m =>
                  ParsecT t1 t m (Column, t, t1)

--- a/version2/src/Modules.hs
+++ b/version2/src/Modules.hs
@@ -1,6 +1,6 @@
 {- PiForall language, OPLSS -}
 
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-orphans #-}
 
 -- | Tools for working with multiple source files
@@ -10,7 +10,23 @@ import Syntax
 import Parser(parseModuleFile, parseModuleImports)
 
 import Text.ParserCombinators.Parsec.Error
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions
 import Control.Applicative 
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet
+import Control.Applicative
+#endif
+
+
+
+
 import Control.Monad.Except
 
 import System.FilePath

--- a/version2/src/Parser.hs
+++ b/version2/src/Parser.hs
@@ -1,6 +1,6 @@
 {- PiForall language, OPLSS -}
 
-{-# LANGUAGE PatternGuards, FlexibleInstances, FlexibleContexts, TupleSections, ExplicitForAll #-}
+{-# LANGUAGE PatternGuards, FlexibleInstances, FlexibleContexts, TupleSections, ExplicitForAll, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-orphans #-}
 
 -- | A parsec-based parser for the concrete syntax.
@@ -22,8 +22,27 @@ import Text.Parsec.Expr(Operator(..),Assoc(..),buildExpressionParser)
 import qualified LayoutToken as Token
 
 import Control.Monad.State.Lazy hiding (join)
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Control.Applicative ( (<$>), (<*>))
+#endif
+
+
+
+
+
 import Control.Monad.Except hiding (join)
+
+
+
 
 import Data.List
 import qualified Data.Set as S
@@ -134,7 +153,7 @@ trellysStyle = Token.LanguageDef
                 , Token.nestedComments = True
                 , Token.identStart     = letter
                 , Token.identLetter    = alphaNum <|> oneOf "_'"
-                , Token.opStart	       = oneOf ":!#$%&*+.,/<=>?@\\^|-"
+                , Token.opStart        = oneOf ":!#$%&*+.,/<=>?@\\^|-"
                 , Token.opLetter       = oneOf ":!#$%&*+.,/<=>?@\\^|-"
                 , Token.caseSensitive  = True
                 , Token.reservedNames =

--- a/version2/src/PrettyPrint.hs
+++ b/version2/src/PrettyPrint.hs
@@ -1,8 +1,6 @@
 {- PiForall language, OPLSS -}
 
-{-# LANGUAGE TypeSynonymInstances,ExistentialQuantification,FlexibleInstances, UndecidableInstances, FlexibleContexts,
-             ViewPatterns, DefaultSignatures, GeneralizedNewtypeDeriving
- #-}
+{-# LANGUAGE TypeSynonymInstances,ExistentialQuantification,FlexibleInstances, UndecidableInstances, ViewPatterns, DefaultSignatures, GeneralizedNewtypeDeriving, FlexibleContexts, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-name-shadowing #-}
 
 -- | A Pretty Printer. 
@@ -19,7 +17,24 @@ import Control.Monad.Reader
 import Text.PrettyPrint as PP
 import Text.ParserCombinators.Parsec.Pos (SourcePos, sourceName, sourceLine, sourceColumn)
 import Text.ParserCombinators.Parsec.Error (ParseError)
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Control.Applicative (Applicative(..), (<$>), (<*>))
+#endif
+
+
+
+
+
+
 import qualified Data.Set as S
 
 -- | The 'Disp' class governs types which can be turned into 'Doc's

--- a/version2/src/Syntax.hs
+++ b/version2/src/Syntax.hs
@@ -8,18 +8,34 @@
              ViewPatterns, 
              EmptyDataDecls,
              DeriveGeneric,
-             DeriveDataTypeable
- #-}
+             DeriveDataTypeable,
+             CPP #-}
 
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches -fno-warn-orphans #-}
+
+
 
 -- | The abstract syntax of the simple dependently typed language
 -- See comment at the top of 'Parser' for the concrete syntax
 
 module Syntax where
 
-import Control.Applicative (pure)
-import Data.Monoid (mempty)
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
+
+-- both needed only on even earlier ghc's
+-- import Control.Applicative (pure)
+-- import Data.Monoid (mempty)
+#endif
+
+
 import GHC.Generics (Generic)
 import Data.Typeable (Typeable)
 

--- a/version2/src/TypeCheck.hs
+++ b/version2/src/TypeCheck.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE ViewPatterns, TypeSynonymInstances, 
              ExistentialQuantification, NamedFieldPuns, 
              ParallelListComp, FlexibleContexts, ScopedTypeVariables, 
-             TupleSections, FlexibleInstances #-}
+             TupleSections, FlexibleInstances, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-unused-matches #-}
 
 -- | The main routines for type-checking 
@@ -16,7 +16,22 @@ import Equal
 
 import Unbound.Generics.LocallyNameless
 import Unbound.Generics.LocallyNameless.Internal.Fold (toListOf)
+
+
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+#if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
+-- ghc >= 7.10.3
+#else
+-- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
+#endif
+#else
+-- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
 import Control.Applicative 
+#endif
+
+
+
+
 import Control.Monad.Except
 import Text.PrettyPrint.HughesPJ
 import Data.Maybe


### PR DESCRIPTION
haven't done any further changes: have used it for several days before
X-mas on both: ghc 7.8.4 and 7.10.3 (now with upgraded packages in
debian testing I have only 7.10.3 avaiable), installation still not in
a sandbox (cf. below)

Note, that my changes really were only in the master directory of the
2014 branch, although there appear to be more changes: full, version1,
and version2 are created from the Makefile in the master directory.

As my comments on these changes are rather sparse, maybe our e-mail
conversation / summary of these changes should go somewhere publicly visible?
(pasted in here for convenience):

> On Dec 16, 2015, at 8:07 PM, Andreas Reuleaux rx@a-rx.info wrote:
> 
> Hi Stephanie,
> 
> I got Pi-forall compiled on ghc 7.10.3.
> 
> I have pushed my changes to to github.com/reuleaux/pi-forall,
> but haven't created a pull request yet: will do so,
> when they are more polished. - I hope I am on the right
> track though.
> 
> Only recently I have discovered, that Pi-forall has
> switched from Unbound+Replib to Unbound-Generics
> (I guess, because I was using another pi-forall.cabal
> file of mine in Pire, that makes Pi-forall available as
> a library), but having discovered Unbound-Generics
> now, compiling with 7.10.3 was not that difficult any more:
> 
> In particular the little changes I mentioned in my other
> e-mail: adjusting display (Pi bnd) because elem requires
> Foldable etc. weren't necessary any more / taken care
> of by Unbound-Generics already, as I understand.
> 
> By the way: what are your long term plans for
> Unbound/Replib vs Unbound-Generics? I see that
> both are actively maintained. Should Pi-forall
> continue to depend on Unbound-Generics ?

I don’t have long term plans in this respect. Alexey Kliger had ported pi-forall 
to unbound-generics over so I pulled his patch. Sometime I’d like to 
benchmark the two different versions of unbound to see which one is faster.  
I haven’t looked much at the difference in the two interfaces though.

> Here's a rough list of my changes:
> - had to introduce 
>   {-# LANGUAGE FlexibleContexts #-}
>   in a couple of places

ok.

> - have converted some tabs to spaces 
>   as the compiler was complaining

thanks. 

> - have introduced conditional imports
>   in various places to take different ghc versions
>   into account - if only to calm down the warnings,
>   which I found distracting, nevertheless, like so:
>   
>     #ifdef MIN_VERSION_GLASGOW_HASKELL
>     #if MIN_VERSION_GLASGOW_HASKELL(7,10,3,0)
>     -- ghc >= 7.10.3
>     #else
>     -- older ghc versions, but MIN_VERSION_GLASGOW_HASKELL defined
>     #endif
>     #else
>     -- MIN_VERSION_GLASGOW_HASKELL not even defined yet (ghc <= 7.8.x)
>     import Data.Monoid 
>     #endif
>   
>   and accordingly I am requiring now
>    {-# LANGUAGE CPP #-}
>   as well
>   
>   there are more places where I can still calm down 
>   the warnings with conditional imports like above
>   
>   I hope that you don't find these preprocessor conditionals too ugly? 
>   they helped me focus on the error messages at least.

I accept them as a bitter necessity.  Please do calm down the error messages. 
But, perhaps we don’t need to support too many older versions of ghc. (i.e. <= 7.8). 

> - have taken the liberty to even change the Makefile in master:
>   - make clean
>     removes "full" now as well (gets recreated with "make full" anyhow),
>     because, if I remember right: some files (like pi-forall.cabal)
>     were copied over to full only if I did a:
>     make clean
>     make full
>     and I needed another "make test_full", to copy over the test files

thanks.

> - only on my older testing system I needed $(flags) for
>    make flags=--force-reinstall full
>   so this may well be a debian testing thing of having too old libraries,
>   will see if I can come up with a better solution

ok.

> - these cabal (re)installs go to my system installation in $HOME,
>   ie. they don't happen in a sandbox, if I am not mistaken,
>   will see if I can make them work in sandboxes

good.

> - while the tests of "make test_full" and "make test_version1" pass fine  
>   there is one test in version2 that fails - still need to look into that:
>   
>     Checking module "NatChurch"
>     Type Error:
>     ../version2/test/NatChurch.pi:38:13:
>       Expected
>         \x zf sf . sf (z x zf sf)
>       but found
>         TRUSTME two
>       in context:
>         test_pred : pred two = one
>       When checking the term  refl against the signature pred two = one
>       In the expression
>         refl
>     Makefile:31: recipe for target 'test_version2' failed
>     make: **\* [test_version2] Error 1

That is an exercise in the file. It should fail.  (Perhaps it needs to be better marked.)

> - what else? - I am sure I forgot something, and I will have
>   more things to add to the list above in the next days.
> - got my Pire code compiling based on the Pi-forall / ghc 7.10.3, too, 
>   but had to make adjustmens there as well, of course.
> 
> Will keep you updated (and send a pull request).

Thanks!

Stephanie
