### PR TITLE
remove nonexistent test suite from cabal file

### DIFF
--- a/version1/pi-forall.cabal
+++ b/version1/pi-forall.cabal
@@ -80,11 +80,3 @@ executable pi-forall
   build-depends: pi-forall
   hs-source-dirs: app
   main-is: Main.hs
-  
-test-suite test-pi-forall
-  import: shared-properties
-  build-depends: pi-forall
-    , QuickCheck >= 2.13.2
-  type: exitcode-stdio-1.0
-  hs-source-dirs: test
-  main-is: Main.hs

--- a/version2/pi-forall.cabal
+++ b/version2/pi-forall.cabal
@@ -80,11 +80,3 @@ executable pi-forall
   build-depends: pi-forall
   hs-source-dirs: app
   main-is: Main.hs
-  
-test-suite test-pi-forall
-  import: shared-properties
-  build-depends: pi-forall
-    , QuickCheck >= 2.13.2
-  type: exitcode-stdio-1.0
-  hs-source-dirs: test
-  main-is: Main.hs


### PR DESCRIPTION
This test suite only exists in version3.

I'm sure this isn't the way you want to fix this, but just letting you know that without this change, or something else to fix this, the build is broken (since it tries to build the test suite and fails).