### PR TITLE
Allow different branch levels

### DIFF
--- a/full/pi/Case.pi
+++ b/full/pi/Case.pi
@@ -3,6 +3,18 @@ module Case where
 data TT : Type @ 0 where
   tt @ 0
 
+elimTT : [P : TT^0 -> Type] -> P tt^0 -> (t : TT^0) -> P t
+elimTT = \[P] Ptt t. case t of
+  tt -> Ptt
+
+elimFunTT : [P : TT^0 -> Type] -> [A : Type] -> (f : A -> TT^0) -> (x : A) -> P tt^0 -> P (f x)
+elimFunTT = \[P] [A] f x Ptt.
+  let g = (\y q. case y of tt -> q
+    : (y : TT^0) -> y = f x -> tt^0 = f x) in
+  let h = (\[y] q py. subst py by q
+    : [y : TT^0] -> y = f x -> P y -> P (f x)) in
+  h [tt^0] (g (f x) Refl) Ptt
+
 data Box : Type @ 1 where
   box of (TT^1) @ 1
 
@@ -15,7 +27,9 @@ h = \P Pb b. case b of
 data X : Type @ 0 where
   c of (Unit) @ 0
 
+{-
 -- This should fail, since it normalizes to \P u. P u, which is ill typed.
 Pu : (P : (x : Unit @ 0) -> Type) -> (u : Unit @ 1) -> Type
 Pu = \P u. case c u of
   c x -> P x
+-}

--- a/full/pi/Case.pi
+++ b/full/pi/Case.pi
@@ -1,13 +1,16 @@
 module Case where
 
 data TT : Type @ 0 where
-  tt @ 1
+  tt @ 0
 
--- This should fail (regardless of the TRUSTME),
--- since the pattern tt has level 1 while the scrutinee has level 0.
-f : [P : (t : TT^0 @ 0) -> Type @ 1] -> (t : TT^0 @ 0) -> P t @ 2
-f = \[P] t. case t of
-  tt -> TRUSTME
+data Box : Type @ 1 where
+  box of (TT^1) @ 1
+
+-- This shouldn't fail, and should match on tt as a displaced constructor
+h : (P : Box^0 -> Type) -> P (box^0 tt^1) -> (b : Box^0) -> P b
+h = \P Pb b. case b of
+  box t -> case t of
+    tt -> Pb
 
 data X : Type @ 0 where
   c of (Unit) @ 0

--- a/full/pi/Case.pi
+++ b/full/pi/Case.pi
@@ -1,0 +1,18 @@
+module Case where
+
+data TT : Type @ 0 where
+  tt @ 1
+
+-- This should fail (regardless of the TRUSTME),
+-- since the pattern tt has level 1 while the scrutinee has level 0.
+f : [P : (t : TT^0 @ 0) -> Type @ 1] -> (t : TT^0 @ 0) -> P t @ 2
+f = \[P] t. case t of
+  tt -> TRUSTME
+
+data X : Type @ 0 where
+  c of (Unit) @ 0
+
+-- This should fail, since it normalizes to \P u. P u, which is ill typed.
+Pu : (P : (x : Unit @ 0) -> Type) -> (u : Unit @ 1) -> Type
+Pu = \P u. case c u of
+  c x -> P x

--- a/full/pi/Equality.pi
+++ b/full/pi/Equality.pi
@@ -76,6 +76,11 @@ sig_equal : [A : Type] -> [B : A -> Type]
           -> ( ( x , b ) : { x : A | B x } ) = (y , subst b by p )
 sig_equal = \[A][B] x y p b . subst Refl by p
 
+-- coercion
+
+coe : [A : Type] -> [B : Type] -> A = B -> A -> B
+coe = \[A] [B] p a. subst a by p
+
 -- not equal is symmetric
 
 neg_eq_sym :  [A:Type] -> [x:A] -> [y:A] -> neg (x = y) -> neg (y = x)

--- a/full/pi/Examples.pi
+++ b/full/pi/Examples.pi
@@ -6,12 +6,13 @@ import Logic
 import BoolLib
 import Product
 import Or
+import Case
 import Fin
 import Equal
 import Equality
 import Fix
 import NatChurch
-import Hurkens
+-- import Hurkens
 -- import HurkensEx
 import IsProp
 import List

--- a/full/pi/Examples.pi
+++ b/full/pi/Examples.pi
@@ -2,8 +2,10 @@ module Examples where
 
 import Blowup
 import Nat
+import Logic
 import BoolLib
 import Product
+import Or
 import Fin
 import Equal
 import Equality
@@ -27,9 +29,6 @@ data Vec (A : Type) (n : Nat) : Type where
 
 v0 : Vec Bool 1
 v0 = Cons [0] True Nil
-
-v3 : Vec Bool 3
-v3 = Cons [2] True (Cons [1] False (Cons [0] False Nil))
 
 loop : Nat
 loop = loop

--- a/full/pi/Lambda.pi
+++ b/full/pi/Lambda.pi
@@ -2,10 +2,10 @@ module Lambda where
 
 import Nat
 import Fin
-import Vec 
+import Vec
 
-lookup : [a:Type] -> [n:Nat] -> Fin n -> Vec a n -> a @ 1
-lookup = \[a][n] f v. case f of 
+lookup : [a:Type @ 1] -> [n:Nat] -> Fin n -> Vec a n -> a @ 2
+lookup = \[a][n] f v. case f of
    Zero [m] -> case v of 
            Cons [m'] x xs -> x 
    Succ [m] f' -> case v of 

--- a/full/pi/Lambda1.pi
+++ b/full/pi/Lambda1.pi
@@ -23,7 +23,7 @@ data Val : Type where
 
 -- Safely access a vector using an index that is known 
 -- to be in bounds.
-nth : [a:Type] -> [n:Nat] -> Vec a n -> Fin n -> a
+nth : [a:Type @ 1] -> [n:Nat] -> Vec a n -> Fin n -> a
 nth = \[a][n] v f. case f of 
    Zero [m] -> case v of 
            Cons [m'] x xs -> x 

--- a/full/pi/List.pi
+++ b/full/pi/List.pi
@@ -14,7 +14,6 @@ map = \[a] [b] f xs . case xs of
 id : [a:Type] -> a -> a
 id = \[a] x . x  
   
-
 f_cong2 : [a : Type]->[b : Type] -> (f : a -> b) -> (a1 : a) -> (a2 : a) -> (a1 = a2) -> f a1 = f a2
 f_cong2 = \[a][b] f a1 a2 pf . subst Refl by pf
 
@@ -25,8 +24,6 @@ map_id = \[a] xs. case xs of
        Cons y ys -> 
          let ih = map_id [a] ys in 
          f_cong2 [List a][List a] (\ys. Cons y ys) (map[a][a](id[a])ys) (id [List a]ys) ih
-
-
 
 append : [a:Type] -> List a -> List a -> List a
 append = \[a] xs ys. case xs of 
@@ -48,4 +45,17 @@ head : [a : Type] -> List a -> a
 head = \[a] xs . case xs of 
   Nil -> TRUSTME  -- cannot remove b/c of exhaustivity check
   Cons y ys -> y
-  
+
+-- Example using lists containing higher-level elements by floating
+-- Displacements explicitly 0 to show they're not needed
+
+data Pack : Type where
+  Packed of [A : Type @ 0] (A)
+
+zapListId : List^0 ([A : Type @ 0] -> A -> A) -> List^0 Pack^0 -> List^0 Pack^0
+zapListId = \fs ps. case fs of
+  Nil -> ps
+  Cons f fs -> case ps of
+    Nil -> Nil^0
+    Cons p ps -> case p of
+      Packed [A] a -> Cons^0 (Packed^0 [A] (f [A] a)) (zapListId fs ps)

--- a/full/pi/Logic.pi
+++ b/full/pi/Logic.pi
@@ -113,9 +113,8 @@ not_both_true_and_false = \[P][Q] andpnp.
   case andpnp of 
     (Conj p np) -> np p
 
-{-
 iff_neg_false : [A : Type] -> iff (neg A) (iff A Void)
 iff_neg_false = \ [A] . Conj (\ x . Conj x (\y. false_elim [A] y)) (proj1 [A -> Void][Void -> A])
--}
-                                  
 
+em_irrefutable : [A : Type] -> neg (neg (Either A (neg A)))
+em_irrefutable = \[A] f. f (Inr (\a. f (Inl a)))

--- a/full/pi/Nat.pi
+++ b/full/pi/Nat.pi
@@ -7,6 +7,8 @@
 
 module Nat where
 
+import Equality
+
 data Nat : Type where
   Zero
   Succ of (Nat)
@@ -20,11 +22,6 @@ pred : Nat -> Nat
 pred = \n . case n of
   Zero -> Zero
   Succ n' -> n'
-
-
-m_eq_n_Sm_eq_Sn : (m:Nat) -> (n:Nat) -> m = n -> ((Succ m : Nat) = Succ n)
-m_eq_n_Sm_eq_Sn = \m n pf . 
-  subst Refl by pf 
 
 nat_eq : Nat -> Nat -> Bool
 nat_eq = \ x y .
@@ -58,8 +55,27 @@ minus = \n m .
                     Succ mpred -> minus pred mpred
 
 -------------------------------------------------------
--- Reasoning about datatypes
+-- Properties of naturals:
+-- * successor is monotone
+-- * successor is injective
+-- * constructors are discriminable
 
+m_eq_n_Sm_eq_Sn : [m:Nat] -> [n:Nat] -> m = n -> (Succ m = Succ n)
+m_eq_n_Sm_eq_Sn = \[m] [n] pf.
+  subst Refl by pf
+
+Sm_eq_Sn_m_eq_n : [m : Nat] -> [n : Nat] -> Succ m = Succ n -> m = n
+Sm_eq_Sn_m_eq_n = \[m] [n] p.
+  f_equal [Nat] [Nat] [pred] [Succ m] [Succ n] p
+
+Z_neq_S : [n : Nat] -> Zero = Succ n -> ((A : Type) -> A)
+Z_neq_S = \[n] p.
+  let split = (\n. case n of Zero -> Unit; Succ m -> (A : Type) -> A : Nat -> Type)
+  in coe [Unit] [(A : Type) -> A] (f_equal [Nat] [Type] [split] [Zero] [Succ n] p) ()
+-- Z_neq_S = \[n] p. contra p
+
+-------------------------------------------------------
+-- Reasoning about datatypes
 
 minus_same_zero : (n : Nat @0) -> ((minus^0) n n = 0) @ 1
 minus_same_zero = \ n .
@@ -89,5 +105,4 @@ plus_associates = \ i j k .
     -- S ((i'+j)+k) = S (i'+(j+k))
     Succ i' -> 
       let ih = (plus_associates i' j k) in
-		m_eq_n_Sm_eq_Sn (plus (plus i' j) k) (plus i' (plus j k)) ih
-
+		m_eq_n_Sm_eq_Sn [plus (plus i' j) k] [plus i' (plus j k)] ih

--- a/full/pi/Or.pi
+++ b/full/pi/Or.pi
@@ -1,0 +1,21 @@
+module Or where
+
+data Or (A : Type @ 0) (B : Type @ 0) : Type @ 2 where
+  Inl of (A) @ 1
+  Inr of (B) @ 3
+
+-- level is forced to be 3 by Inr's level
+id : [A : Type @ 0] -> [B : Type @ 0] -> Or^0 A B -> Or^0 A B
+id = \[A] [B] or. case or of
+  Inl a -> Inl a
+  Inr b -> Inr b
+
+id2 : [A : Type @ 0] -> [B : Type @ 0] -> Or^0 A B -> Or^0 A B @ 2
+id2 = \[A] [B] or. case or of
+  Inl a -> Inl a
+  -- Impossible case: Inr b -> Inr b
+
+id3 : [A : Type @ 0] -> [B : Type @ 0] -> Or^0 A B -> Or^0 A B @ 3
+id3 = \[A] [B] or. case or of
+  Inl a -> Inl a
+  Inr b -> Inr b

--- a/full/pi/Or.pi
+++ b/full/pi/Or.pi
@@ -2,7 +2,7 @@ module Or where
 
 data Or (A : Type @ 0) (B : Type @ 0) : Type @ 2 where
   Inl of (A) @ 1
-  Inr of (B) @ 3
+  Inr of (B) @ 2 -- cannot be @ 3
 
 -- level is forced to be 3 by Inr's level
 id : [A : Type @ 0] -> [B : Type @ 0] -> Or^0 A B -> Or^0 A B
@@ -10,9 +10,10 @@ id = \[A] [B] or. case or of
   Inl a -> Inl a
   Inr b -> Inr b
 
-id2 : [A : Type @ 0] -> [B : Type @ 0] -> Or^0 A B -> Or^0 A B @ 2
-id2 = \[A] [B] or. case or of
-  Inl a -> Inl a
+-- no longer possible since Inr cannot be @ 3
+-- id2 : [A : Type @ 0] -> [B : Type @ 0] -> Or^0 A B -> Or^0 A B @ 2
+-- id2 = \[A] [B] or. case or of
+--   Inl a -> Inl a
   -- Impossible case: Inr b -> Inr b
 
 id3 : [A : Type @ 0] -> [B : Type @ 0] -> Or^0 A B -> Or^0 A B @ 3

--- a/full/pi/Ord.pi
+++ b/full/pi/Ord.pi
@@ -1,0 +1,66 @@
+module Ord where
+
+import Logic
+import List
+
+data Void : Type where {}
+
+-- Ordinals and their order
+
+data Ord : Type where
+  Succ of (Ord)
+  Lim of [X : Type] (X -> Ord)
+
+data Leq (o1 : Ord) (o2 : Ord) : Type where
+  Mono     of (o1' : Ord) (o2' : Ord) (Leq o1' o2') [o1 = Succ o1'] [o2 = Succ o2']
+  Cocone   of [A : Type] (f : A -> Ord)  (a : A)   (Leq o1 (f a)) [o2 = Lim [A] f]
+  Limiting of [A : Type] (f : A -> Ord) ((a : A) -> Leq (f a) o2) [o1 = Lim [A] f]
+
+lt : Ord -> Ord -> Type
+lt = \o1 o2. Leq (Succ o1) o2
+
+zero : Ord
+zero = Lim [Void] (\v. case v of {})
+
+-- Properties of the order
+
+zeroLeq : [o : Ord] -> Leq zero o
+zeroLeq = \[o]. Limiting [Void] (\v. case v of {}) (\v. case v of {})
+
+reflLeq : (o : Ord) -> Leq o o
+reflLeq = \o. case o of
+  Succ o -> Mono o o (reflLeq o)
+  Lim [X] f -> Limiting [X] f (\x. Cocone [X] f x (reflLeq (f x)))
+
+transLeq : [o1 : Ord] -> [o2 : Ord] -> [o3 : Ord] -> Leq o1 o2 -> Leq o2 o3 -> Leq o1 o3
+transLeq = \[o1] [o2] [o3] leq1 leq2. case leq1 of
+  Mono o1' o2' leq1' -> case leq2 of
+    Mono o2' o3' leq2' -> Mono o1' o3' (transLeq [o1'] [o2'] [o3'] leq1' leq2')
+    Cocone [A] f a leq2' -> Cocone [A] f a (transLeq [o1] [o2] [f a] leq1 leq2')
+  Cocone [A] f a leq1' -> case leq2 of
+    Cocone [A] f a leq2' -> Cocone [A] f a (transLeq [o1] [o2] [f a] leq1 leq2')
+    Limiting [A] f h -> transLeq [o1] [f a] [o3] leq1' (h a)
+  Limiting [A] f h -> Limiting [A] f (\a. transLeq [f a] [o2] [o3] (h a) leq2)
+
+succLeq : (o : Ord) -> Leq o (Succ o)
+succLeq = \o. case o of
+  Succ o -> Mono o (Succ o) (succLeq o)
+  Lim [X] f -> Limiting [X] f
+    (\x. transLeq [f x] [Succ (f x)] [Succ (Lim [X] f)]
+      (succLeq (f x))
+      (Mono (f x) (Lim [X] f)
+        (Cocone [X] f x (reflLeq (f x)))))
+
+-- Ordinal addition?
+
+add : Ord -> Ord -> Ord
+add = \o1 o2. case o1 of
+  Succ o -> Succ (add o o2)
+  Lim [X] f -> case o2 of
+    Succ o -> Succ (add o1 o)
+    Lim [Y] g -> Lim [Either X Y] (\xy. case xy of Inl x -> f x; Inr y -> g y)
+
+sumOrds : List Ord -> Ord
+sumOrds = \l. case l of
+  Nil -> zero
+  Cons o os -> add o (sumOrds os)

--- a/full/pi/Product.pi
+++ b/full/pi/Product.pi
@@ -122,3 +122,28 @@ uncurry' :  [A:Type] -> [B:Type] -> [C : Times A B -> Type] ->
 uncurry' = \[A][B]. uncurry [A][\x.B] 
 -}
 
+---------------------------------------------------
+-- Extra dependent pairs
+
+data Pair (A : Type @ 0) (B : (x : A @ 0) -> Type) : Type @ 1 where
+  MkPair of (x : A @ 0) (B x)
+
+fst : [A : Type @ 0] -> [B : (x : A @ 0) -> Type @ 1] -> Pair A B -> A @ 2
+fst = \[A] [B] p. case p of
+	MkPair a b -> a
+
+-- This won't type check because fst is too big, and lifting B doesn't lift its domain level
+-- snd : [A : Type @ 0] -> [B : (x : A @ 0) -> Type @ 1] -> (p : Pair A B @ 1) -> B (fst [A] [B] p) @ 2
+
+-- However, this allows us to define pairs where B uses the element of A dependently
+Prop : Type @ 1
+Prop = Pair Type (\A. (x : A @ 0) -> (y : A @ 0) -> x = y)
+
+-- On the other hand, Prop can't be defined using Sig,
+-- since the level of B will always end up being strictly larger than that of A
+-- Prop' : Type @ 1
+-- Prop' = Sig Type (\A. (x : A @ 0) -> (y : A @ 0) -> x = y)
+
+-- These are the tradeoffs between the two different kinds of dependent pairs:
+-- * Pair doesn't have second projections, but lets B use the first projection dependently
+-- * Sig doesn't allow fixing the level of the first projection, which enables second projections

--- a/full/pi/Product.pi
+++ b/full/pi/Product.pi
@@ -84,7 +84,7 @@ data Refine (A:Type @ 0) (B : A -> Type) : Type where
 
 rproj1 : [A:Type] -> [B:A -> Type] -> Refine A B -> A 
 rproj1 = \[A][B] x . case x of 
-  Product x y -> x
+  Product x [y] -> x
 
 ---------------------------------------------------
 -- Non-dependent version 

--- a/full/pi/Product.pi
+++ b/full/pi/Product.pi
@@ -61,8 +61,8 @@ uncurry = \ [A][B][C] f p . case p of
 ---------------------------------------------------
 -- Irr first component
 
-data Exists (A:Type)(B: A -> Type) : Type where
-  Product of [x:A](B x)
+data Exists (A:Type @ 0) (B: A -> Type) : Type where
+  Product of [x:A] (B x)
 
 -- can't define the first projections for this type
 
@@ -79,7 +79,7 @@ eproj2 = \[A][B] x . case x of
 ---------------------------------------------------
 -- Irr second component
 
-data Refine (A:Type) (B : A -> Type) : Type where
+data Refine (A:Type @ 0) (B : A -> Type) : Type where
   Product of (x:A)[B x]
 
 rproj1 : [A:Type] -> [B:A -> Type] -> Refine A B -> A 

--- a/full/pi/Vec.pi
+++ b/full/pi/Vec.pi
@@ -154,27 +154,18 @@ foldl = \[A] [m] [B] f z v .
 	    let n' = f [0] z x in
        foldl [A][m'][\ n'. B (Succ n')] (\[n] b a . f [Succ n] b a) n' xs
 
-
-fst : [A:Type] -> [B:A -> Type] -> { x : A | B x } -> A
-fst = \[A][B] x . let (y,z) = x in y 
-
-snd : [A:Type] -> [B:A -> Type] -> (p : { x:A | B x}) -> B (fst[A][B] p)
-snd = \[A][B] x . let (y,z) = x in z
-
 -- note that in pi-forall, we only have one notion of irrelevance: 
 -- arguments are either erasable and ignorable, or they are relevant.
-
-{-
+-- we can't use fst/snd here because the level of snd is greater than the returned pair,
+-- so we can't construct a new pair that fits in the return level.
 filter : [A:Type] -> [n:Nat] -> (A -> Bool) -> 
-       Vec A n -> { m : Nat | Vec A m } 
+       Vec A n -> { m : Nat | Vec A m }
 filter = \ [A][n] f v . 
    case v of 
      Nil -> ( 0 , Nil )
      Cons [n'] x xs -> 
-        let p = filter [A][n'] f xs in 
-        let m' = fst [Nat] [\n. Vec A n] p in
-        let xs' = snd [Nat] [\n. Vec A n] p in
+        let p = filter [A][n'] f xs in
+        let (m', xs') = p in
         if f x
-           then (Succ m' , Cons [m'] x xs')
+           then (Succ m', Cons [m'] x xs')
            else (m', xs')
--}

--- a/full/pi/Vec.pi
+++ b/full/pi/Vec.pi
@@ -13,8 +13,8 @@ import Nat
 import Fin
 import Product
 
-data Vec (A : Type) (n : Nat) : Type @ 0 where
-  Nil  of                       [n = Zero] 
+data Vec (A : Type) (n : Nat) : Type where
+  Nil  of                       [n = Zero]
   Cons of [m:Nat] (A) (Vec A m) [n = Succ m]
 
 -- A vector with exactly three boolean values
@@ -32,13 +32,16 @@ tail = \ [A][n] x.  case x of
      -- Nil case impossible
      Cons [m] y ys -> ys
 
+vecId : [A : Type] -> [m : Nat] -> Vec A m -> Vec A m
+vecId = \[A] [m] v. case v of
+  Cons [n] hd tl -> Cons [n] hd (vecId [A] [n] tl)
+  Nil -> v
 
-append : [A :Type @0] ->[m:Nat^0 @0] -> [n:Nat^0 @0] -> Vec^0 A m -> Vec^0 A n -> Vec^0 A (plus^0 m n) @1
+append : [A :Type] ->[m:Nat] -> [n:Nat] -> Vec A m -> Vec A n -> Vec A (plus m n)
 append = \[A] [m] [n] v1 ys . case v1 of 
-     Cons [m0] x xs -> Cons^1 [plus^0 m0 n] x (append [A] [m0][n] xs ys)
+     Cons [m0] x xs -> Cons [plus m0 n] x (append [A] [m0][n] xs ys)
      Nil -> ys
 
-{-
 zap : [A:Type] -> [B: Type] -> [n:Nat] -> Vec (A -> B) n -> Vec A n -> Vec B n
 zap = \[A][B] [n] vs1 vs2 . 
   case vs1 of 
@@ -111,7 +114,7 @@ foldr'' = \[A][B] m f n v .
         Cons [m2] x xs -> 
           f m1 x (foldr'' [A][B] m1 f n xs)
           
-data In (A:Type) (x:A) (n:Nat) (v:Vec A n) : Type where
+data In (A:Type @ 0) (x:A) (n:Nat @ 0) (v:Vec A n) : Type where
   Here  of [m:Nat][n = Succ m][xs : Vec A m] 
            [v = Cons [m] x xs]
   There of [m:Nat][n = Succ m][xs : Vec A m] 
@@ -157,8 +160,6 @@ fst = \[A][B] x . let (y,z) = x in y
 
 snd : [A:Type] -> [B:A -> Type] -> (p : { x:A | B x}) -> B (fst[A][B] p)
 snd = \[A][B] x . let (y,z) = x in z
-  
--}
 
 -- note that in pi-forall, we only have one notion of irrelevance: 
 -- arguments are either erasable and ignorable, or they are relevant.

--- a/full/pi/WFU.pi
+++ b/full/pi/WFU.pi
@@ -9,7 +9,7 @@ data U : Type where
 -- A U is well-founded if all its elements are
 -- (No infinite chains of elements)
 data WF (u : U) : Type where
-   Mk_WF of [X : Type] [f : X -> U] ((x : X) -> WF (f x)) [u = Mk_U X f]
+   Mk_WF of [X : Type] [f : X -> U @ 1] ((x : X @ 1) -> WF (f x)) [u = Mk_U X f]
 
 
 -- All U are well-founded

--- a/full/pi/WFUAnnot.pi
+++ b/full/pi/WFUAnnot.pi
@@ -14,9 +14,13 @@ always_WF : (x : U^0 @ 1) -> WF^0 x @ 2
 always_WF = \u. case u of 
    (Mk_U X f) -> Mk_WF^0 [X] [f] (\x. always_WF (f x))
 
+liftU : U^0 -> U^1
+liftU = \u. case u of
+   Mk_U X f -> Mk_U^1 X (\x. liftU (f x))
+
 -- But this one is not
 loop : U^1 @ 2
-loop = Mk_U U^0 (\x. x)
+loop = Mk_U^1 U^0 liftU^0
 
 not_WF : WF^1 loop^0 -> Void^0 @ 3
 not_WF = \y. case y of

--- a/full/pi/WFUAnnot.pi
+++ b/full/pi/WFUAnnot.pi
@@ -6,7 +6,7 @@ data U : Type @ 0 where
    Mk_U of (X : Type @ 0) (X -> U) @ 1
 
 -- A U is well-founded if all its elements are
-data WF (u : U) : Type @ 0 where
+data WF (u : U) : Type @ 2 where
    Mk_WF of [X : Type @ 0] [f : X -> U @ 1] ((x : X @ 1) -> WF (f x)) [u = Mk_U X f] @ 2
 
 -- All U are well-founded
@@ -18,7 +18,7 @@ always_WF = \u. case u of
 loop : U^0 @ 1
 loop = Mk_U^0 U^0 (\x. x)
 
-not_WF : WF^0 loop -> Void^0 @ 2
+not_WF : WF^0 loop^0 -> Void^0 @ 2
 not_WF = \y. case y of
    Mk_WF [X] [f] x -> not_WF (x loop^0)
 

--- a/full/pi/WFUAnnot.pi
+++ b/full/pi/WFUAnnot.pi
@@ -2,7 +2,7 @@ module WFUAnnot where
 
 data Void : Type @ 0 where {}
 
-data U : Type @ 0 where
+data U : Type @ 1 where
    Mk_U of (X : Type @ 0) (X -> U) @ 1
 
 -- A U is well-founded if all its elements are
@@ -15,10 +15,10 @@ always_WF = \u. case u of
    (Mk_U X f) -> Mk_WF^0 [X] [f] (\x. always_WF (f x))
 
 -- But this one is not
-loop : U^0 @ 1
-loop = Mk_U^0 U^0 (\x. x)
+loop : U^1 @ 2
+loop = Mk_U U^0 (\x. x)
 
-not_WF : WF^0 loop^0 -> Void^0 @ 2
+not_WF : WF^1 loop^0 -> Void^0 @ 3
 not_WF = \y. case y of
    Mk_WF [X] [f] x -> not_WF (x loop^0)
 

--- a/full/pi/WFUAnnot.pi
+++ b/full/pi/WFUAnnot.pi
@@ -1,0 +1,26 @@
+module WFUAnnot where
+
+data Void : Type @ 0 where {}
+
+data U : Type @ 0 where
+   Mk_U of (X : Type @ 0) (X -> U) @ 1
+
+-- A U is well-founded if all its elements are
+data WF (u : U) : Type @ 0 where
+   Mk_WF of [X : Type @ 0] [f : X -> U @ 1] ((x : X @ 1) -> WF (f x)) [u = Mk_U X f] @ 2
+
+-- All U are well-founded
+always_WF : (x : U^0 @ 1) -> WF^0 x @ 2
+always_WF = \u. case u of 
+   (Mk_U X f) -> Mk_WF^0 [X] [f] (\x. always_WF (f x))
+
+-- But this one is not
+loop : U^0 @ 1
+loop = Mk_U^0 U^0 (\x. x)
+
+not_WF : WF^0 loop -> Void^0 @ 2
+not_WF = \y. case y of
+   Mk_WF [X] [f] x -> not_WF (x loop^0)
+
+false : Void^0
+false = not_WF^0 (always_WF^0 loop^0)

--- a/full/src/Environment.hs
+++ b/full/src/Environment.hs
@@ -357,7 +357,6 @@ instance Semigroup Err where
 
 instance Monoid Err where
   mempty = Err [] mempty
-  mappend (Err src1 d1) (Err src2 d2) = Err (src1 ++ src2) (d1 `mappend` d2)
 
 instance Disp Err where
   disp (Err [] msg) = msg
@@ -394,8 +393,6 @@ withStage :: (MonadReader Env m) => Rho -> m a -> m a
 withStage Irr = extendCtx (Demote Rel)
 withStage ep = id
 
-
-
 extendLevelConstraint :: (MonadReader Env m, MonadError Err m, MonadState TcState m) => LevelConstraint -> m ()
 extendLevelConstraint c@(Lt (LConst i) (LConst j)) =
     if i < j then return () else err [DS "Cannot solve constraint", DD c]
@@ -431,8 +428,8 @@ simplify :: [(SourceLocation,LevelConstraint)] -> [(SourceLocation,LevelConstrai
 simplify [] = []
 simplify ((p, c@(Eq j k)) : r) =
   case (reduce j, reduce k) of
-    (LVar x , k') -> (p , Eq (LVar x) k') : simplify (map (\(p,c) -> (p, Unbound.subst x k' c)) r)
-    (k', LVar x)  -> (p , Eq (LVar x) k') : simplify (map (\(p,c) -> (p, (Unbound.subst x k' c))) r)
+    (LVar x , k') -> (p , Eq (LVar x) k') : simplify (map (\(p', c') -> (p', Unbound.subst x k' c')) r)
+    (k', LVar x)  -> (p , Eq (LVar x) k') : simplify (map (\(p', c') -> (p', Unbound.subst x k' c')) r)
     (LConst i1, LConst i2) | i1 == i2 -> simplify r
     (j', k') -> (p, Eq j' k') : simplify r
 simplify ((p, Lt j k) : r) = 

--- a/full/src/Equal.hs
+++ b/full/src/Equal.hs
@@ -115,16 +115,17 @@ equate' d t1 t2 = do
     (Refl,  Refl) -> return success
 
     (TCon c1 j1 ts1, TCon c2 j2 ts2) -> do
-      equateLevel j1 j2
+      crs <- equateLevel j1 j2
       if c1 == c2 then do
         rs <- zipWithM (equateArgs d) [ts1] [ts2]
-        return (mconcat rs)
+        return (crs ++ mconcat rs)
       else
         tyErr c2 c1
 
     (DCon d1 j1 a1, DCon d2 j2 a2) | d1 == d2 -> do
-      equateLevel j1 j2
-      equateArgs d a1 a2
+      drs <- equateLevel j1 j2
+      ars <- equateArgs d a1 a2
+      return (drs ++ ars)
     (_,_) -> do
         -- For terms that do not have matching head forms, 
         -- first see if they are "shallowly" equal i.e. alpha-equivalent

--- a/full/src/Parser.hs
+++ b/full/src/Parser.hs
@@ -712,12 +712,12 @@ displaceTm = do
   x <- variable
   reservedOp "^"
   l <- try (LConst <$> natural) <|> do
-    lv <- Unbound.fresh (Unbound.string2Name "l")
+    lv <- Unbound.fresh (Unbound.string2Name "d")
     return (LVar lv)
   return $ Displace (Var x) l
 
 displace :: LParser Level
 displace = do
   try (reservedOp "^" *> (LConst <$> natural)) <|> do
-    lv <- Unbound.fresh (Unbound.string2Name "l")
+    lv <- Unbound.fresh (Unbound.string2Name "d")
     return (LVar lv) 

--- a/full/src/Syntax.hs
+++ b/full/src/Syntax.hs
@@ -287,6 +287,11 @@ isPatVar :: Pattern -> Bool
 isPatVar (PatVar _) = True
 isPatVar _ = False
 
+-- | Is this declaration a type signature
+isTypeSig :: Decl -> Bool
+isTypeSig (TypeSig _) = True
+isTypeSig _ = False
+
 -------------------------------------------------------------------
 -- Prelude declarations for datatypes
 

--- a/full/src/TypeCheck.hs
+++ b/full/src/TypeCheck.hs
@@ -558,8 +558,8 @@ data HintOrCtx
   = AddHint Sig
   | AddCtx [Decl]
 
-dcons cs = concatMap (\(Env.SourceLocation p _, c)-> [DD p, DD c]) cs
-
+displayConstraints :: [(Env.SourceLocation, LevelConstraint)] -> [D]
+displayConstraints = concatMap (\(Env.SourceLocation p _, c) -> [DD p, DD c])
 
 dumpAndSolve :: (Unbound.Alpha a, Disp a) => a -> TcMonad [(LName, Level)]
 dumpAndSolve tm = do
@@ -570,7 +570,7 @@ dumpAndSolve tm = do
   case mss of
         Nothing -> Env.err $ [DS "Cannot satisfy level constraints.",
                      DS "Term is:", DD tm,
-                     DS "Constraints are "] ++ dcons (Env.simplify cs)
+                     DS "Constraints are "] ++ displayConstraints (Env.simplify cs)
         Just ss -> return (ss ++ ss')
 
 -- | Check each sort of declaration in a module
@@ -683,7 +683,7 @@ duplicateTypeBindingCheck sig = do
               DS "Previous was",
               DD sig'
             ]
-       in Env.extendSourceLocation p sig $ Env.err msg
+      in Env.extendSourceLocation p sig $ Env.err msg
 
 -----------------------------------------------------------
 -- Checking that pattern matching is exhaustive

--- a/full/src/TypeCheck.hs
+++ b/full/src/TypeCheck.hs
@@ -205,9 +205,8 @@ tcTerm t@(DCon c j0 args) Nothing mk = do
             DD (length args),
             DS "arguments."
           ]
-      -- TODO: check whether this should be mk or j
       Telescope deltai' <- Equal.displaceTele j0 (Telescope deltai)
-      args' <- tcArgTele args deltai' mk
+      args' <- tcArgTele args deltai' j
       return (TCon tname j0 [], DCon c j0 args)
 
     [_] ->
@@ -242,7 +241,7 @@ tcTerm t@(DCon c j0 args) (Just ty) mk = do
       Telescope delta' <- Equal.displaceTele j0 (Telescope delta)
       Telescope deltai' <- Equal.displaceTele j0 (Telescope deltai)
       newTele <- substTele delta params deltai'
-      args' <- tcArgTele args newTele mk
+      args' <- tcArgTele args newTele j
       return (ty, DCon c j0 args')
     _ ->
       Env.err [DS "Unexpected type", DD ty, DS "for data constructor", DD t]

--- a/full/src/TypeCheck.hs
+++ b/full/src/TypeCheck.hs
@@ -643,6 +643,7 @@ tcEntry decl@(Data t (Telescope delta) cs k) =
           Env.extendSourceLocation pos defn $
             Env.extendCtx (DataSig t (Telescope delta) k) $
               Env.extendCtxTele ldelta $ do
+                Env.extendLevelConstraint (Le ck k)
                 etele <- tcTypeTele tele ck
                 return (ConstructorDef pos d (Telescope etele) ck)
     ecs <- mapM elabConstructorDef cs

--- a/full/src/TypeCheck.hs
+++ b/full/src/TypeCheck.hs
@@ -650,6 +650,7 @@ tcEntry decl@(Data t (Telescope delta) cs k) =
           Env.extendSourceLocation pos defn $
             Env.extendCtx (DataSig t (Telescope delta) k) $
               Env.extendCtxTele ldelta $ do
+                _ <- Env.extendLevelConstraint (Eq k ck)
                 etele <- tcTypeTele tele ck
                 return (ConstructorDef pos d (Telescope etele) ck)
     ecs <- mapM elabConstructorDef cs

--- a/full/src/TypeCheck.hs
+++ b/full/src/TypeCheck.hs
@@ -732,7 +732,7 @@ exhaustivityCheck scrut ty j pats = do
             ( do
                 Env.extendLevelConstraint (Le ck j)
                 tele' <- substTele delta tys tele
-                _ <- tcTypeTele tele' ck --TODO check this!!
+                _ <- tcTypeTele tele' ck
                 return [dc]
               )
               `catchError` (\_ -> return [])

--- a/full/src/TypeCheck.hs
+++ b/full/src/TypeCheck.hs
@@ -257,9 +257,6 @@ tcTerm t@(Case scrut alts) (Just ty) mk = do
         (pat, body) <- Unbound.unbind bnd
         -- add variables from pattern to context
         -- could fail if branch is in-accessible
-        -- levels of constructors of each branch can be different,
-        -- but must at least fit in the level of the scrutinee
-        -- so that motive remains well typed
         decls <- declarePat pat (Mode Rel (Just j)) (TCon c d0 args)
         -- add defs to the contents from scrut = pat
         -- could fail if branch is in-accessible

--- a/full/test/Main.hs
+++ b/full/test/Main.hs
@@ -28,4 +28,4 @@ testFile name = name ~: TestCase $ do
   val <- v `exitWith` (\b -> assertFailure $ "Parse error: " ++ render (disp b))
   d <- runTcMonad emptyEnv (tcModules val)
   defs <- d `exitWith` (\s -> assertFailure $ "Type error:" ++ render (disp s))
-  putStrLn $ render $ disp (last defs)
+  putStrLn $ render $ disp (last (fst defs))


### PR DESCRIPTION
In case expressions, the pattern is unified against the scrutinee, so if the constructor's level is different from the inductive's level, the pattern's level will differ from that of the scrutinee, and unification will fail.