### PR TITLE
Add position to PRINTME parser

### DIFF
--- a/full/src/Parser.hs
+++ b/full/src/Parser.hs
@@ -403,7 +403,10 @@ trustme :: LParser Term
 trustme = reserved "TRUSTME" *> return (TrustMe )
 
 printme :: LParser Term
-printme = reserved "PRINTME" *> return (PrintMe )
+printme = do
+  pos <- getPosition
+  reserved "PRINTME"
+  return (Pos pos PrintMe )
 
 refl :: LParser Term
 refl =

--- a/main/src/Parser.hs
+++ b/main/src/Parser.hs
@@ -434,7 +434,10 @@ trustme :: LParser Term
 trustme = reserved "TRUSTME" *> return (TrustMe )
 
 printme :: LParser Term
-printme = reserved "PRINTME" *> return (PrintMe )
+printme = do
+  pos <- getPosition
+  reserved "PRINTME"
+  return (Pos pos PrintMe )
 
 {- SOLN EQUAL -}
 refl :: LParser Term

--- a/version1/src/Parser.hs
+++ b/version1/src/Parser.hs
@@ -258,7 +258,10 @@ trustme :: LParser Term
 trustme = reserved "TRUSTME" *> return (TrustMe)
 
 printme :: LParser Term
-printme = reserved "PRINTME" *> return (PrintMe)
+printme = do
+  pos <- getPosition
+  reserved "PRINTME"
+  return (Pos pos PrintMe)
 
 -- Expressions
 

--- a/version2/src/Parser.hs
+++ b/version2/src/Parser.hs
@@ -274,7 +274,10 @@ trustme :: LParser Term
 trustme = reserved "TRUSTME" *> return (TrustMe )
 
 printme :: LParser Term
-printme = reserved "PRINTME" *> return (PrintMe )
+printme = do
+  pos <- getPosition
+  reserved "PRINTME"
+  return (Pos pos PrintMe )
 
 refl :: LParser Term
 refl =

--- a/version3/src/Parser.hs
+++ b/version3/src/Parser.hs
@@ -277,7 +277,10 @@ trustme :: LParser Term
 trustme = reserved "TRUSTME" *> return (TrustMe )
 
 printme :: LParser Term
-printme = reserved "PRINTME" *> return (PrintMe )
+printme = do
+  pos <- getPosition
+  reserved "PRINTME"
+  return (Pos pos PrintMe )
 
 refl :: LParser Term
 refl =


### PR DESCRIPTION
I was revisiting pi-forall this week and updated my vscode extension to show errors and warnings in the editor. I noticed that the positions for `PRINTME` were not always accurate. For example the output of `plus 1 PRINTME` points to the `plus` instead of the `PRINTME`.  So I've added a `Pos` around `PrintMe` to tighten up the position.
