### PR TITLE
Slight improvement in `C-CASE-SIMPLE` and typo in `C-CONTRA`

### DIFF
--- a/doc/data.ott
+++ b/doc/data.ott
@@ -146,11 +146,11 @@ G |- ImTrue a1 a2 : SillyBool
    
 G |- a : T
 </ G |- pati : T => Di // i />
-</ G, Di |- ai : A // i />
-G |- A : Type
+</ G, Di |- bi : B // i />
+G |- B : Type
 branches exhaustive
 ---------------------------------------------------- :: case_simple
-G |- case a of { </ pati -> ai // i /> } : A
+G |- case a of { </ pati -> bi // i /> } : B
 
 
 
@@ -183,10 +183,10 @@ G |- a => A
 whnf G |-  A ~> T
 </ G |- pati : T => Di // i />
 </ |- a ~ pati => Di' // i />
-</ G, Di , Di' |- ai : A // i />
+</ G, Di , Di' |- bi <= B // i />
 branches exhaustive
 --------------------------------------------------------  :: case_simple
-G |- case a of { </ pati -> ai // i /> } <= A
+G |- case a of { </ pati -> bi // i /> } <= B
 
 
 G |- a => A

--- a/doc/oplss.mng
+++ b/doc/oplss.mng
@@ -2447,7 +2447,7 @@ be referred to in any of the telescopes for the data constructors.
 \begin{piforall}
 data Maybe (A : Type) : Type where
     Nothing
-     Just of (A)
+    Just of (A)
 
 \end{piforall}
 

--- a/doc/pi-rules.tex
+++ b/doc/pi-rules.tex
@@ -1598,7 +1598,7 @@
 
 
 \newcommand{\ottdrulecXXcontra}[1]{\ottdrule[#1]{%
-\ottpremise{\Gamma  \vdash  \ottnt{a}  \ottsym{:}  \ottnt{A}}%
+\ottpremise{\Gamma  \vdash  \ottnt{a}  \Rightarrow  \ottnt{A}}%
 \ottpremise{ \Gamma   \vdash   \ottkw{whnf} \  \ottnt{A}  \leadsto  \ottsym{(}  \ottnt{a_{{\mathrm{1}}}}  \ottsym{=}  \ottnt{a_{{\mathrm{2}}}}  \ottsym{)} }%
 \ottpremise{ \Gamma   \vdash   \ottkw{whnf} \  \ottnt{a_{{\mathrm{1}}}}  \leadsto  \ottkw{True} }%
 \ottpremise{ \Gamma   \vdash   \ottkw{whnf} \  \ottnt{a_{{\mathrm{2}}}}  \leadsto  \ottkw{False} }%

--- a/doc/pi-rules.tex
+++ b/doc/pi-rules.tex
@@ -1107,11 +1107,11 @@
 \newcommand{\ottdruletXXcaseXXsimple}[1]{\ottdrule[#1]{%
 \ottpremise{\Gamma  \vdash  \ottnt{a}  \ottsym{:}  \ottmv{T} \, }%
 \ottpremise{\ottcomp{\Gamma  \vdash  \ottnt{pat_{\ottmv{i}}}  \ottsym{:}  \ottmv{T} \,   \Rightarrow  \Delta_{\ottmv{i}}}{\ottmv{i}}}%
-\ottpremise{\ottcomp{\Gamma  \ottsym{,}  \Delta_{\ottmv{i}}  \vdash  \ottnt{a_{\ottmv{i}}}  \ottsym{:}  \ottnt{A}}{\ottmv{i}}}%
-\ottpremise{\Gamma  \vdash  \ottnt{A}  \ottsym{:}  \ottkw{Type}}%
+\ottpremise{\ottcomp{\Gamma  \ottsym{,}  \Delta_{\ottmv{i}}  \vdash  \ottnt{b_{\ottmv{i}}}  \ottsym{:}  \ottnt{B}}{\ottmv{i}}}%
+\ottpremise{\Gamma  \vdash  \ottnt{B}  \ottsym{:}  \ottkw{Type}}%
 \ottpremise{\ottkw{branches} \, \ottkw{exhaustive}}%
 }{
-\Gamma  \vdash  \ottkw{case} \, \ottnt{a} \, \ottkw{of} \, \ottsym{\{} \, \ottcomp{\ottnt{pat_{\ottmv{i}}}  \to  \ottnt{a_{\ottmv{i}}}}{\ottmv{i}} \, \ottsym{\}}  \ottsym{:}  \ottnt{A}}{%
+\Gamma  \vdash  \ottkw{case} \, \ottnt{a} \, \ottkw{of} \, \ottsym{\{} \, \ottcomp{\ottnt{pat_{\ottmv{i}}}  \to  \ottnt{b_{\ottmv{i}}}}{\ottmv{i}} \, \ottsym{\}}  \ottsym{:}  \ottnt{B}}{%
 {\ottdrulename{t\_case\_simple}}{}%
 }}
 
@@ -1613,10 +1613,10 @@
 \ottpremise{ \Gamma   \vdash   \ottkw{whnf} \  \ottnt{A}  \leadsto  \ottmv{T} \,  }%
 \ottpremise{\ottcomp{\Gamma  \vdash  \ottnt{pat_{\ottmv{i}}}  \ottsym{:}  \ottmv{T} \,   \Rightarrow  \Delta_{\ottmv{i}}}{\ottmv{i}}}%
 \ottpremise{\ottcomp{\vdash  \ottnt{a}  \sim  \ottnt{pat_{\ottmv{i}}}  \Rightarrow  \Delta'_{\ottmv{i}}}{\ottmv{i}}}%
-\ottpremise{\ottcomp{\Gamma  \ottsym{,}  \Delta_{\ottmv{i}}  \ottsym{,}  \Delta'_{\ottmv{i}}  \vdash  \ottnt{a_{\ottmv{i}}}  \ottsym{:}  \ottnt{A}}{\ottmv{i}}}%
+\ottpremise{\ottcomp{\Gamma  \ottsym{,}  \Delta_{\ottmv{i}}  \ottsym{,}  \Delta'_{\ottmv{i}}  \vdash  \ottnt{b_{\ottmv{i}}}  \Leftarrow  \ottnt{B}}{\ottmv{i}}}%
 \ottpremise{\ottkw{branches} \, \ottkw{exhaustive}}%
 }{
-\Gamma  \vdash  \ottkw{case} \, \ottnt{a} \, \ottkw{of} \, \ottsym{\{} \, \ottcomp{\ottnt{pat_{\ottmv{i}}}  \to  \ottnt{a_{\ottmv{i}}}}{\ottmv{i}} \, \ottsym{\}}  \Leftarrow  \ottnt{A}}{%
+\Gamma  \vdash  \ottkw{case} \, \ottnt{a} \, \ottkw{of} \, \ottsym{\{} \, \ottcomp{\ottnt{pat_{\ottmv{i}}}  \to  \ottnt{b_{\ottmv{i}}}}{\ottmv{i}} \, \ottsym{\}}  \Leftarrow  \ottnt{B}}{%
 {\ottdrulename{c\_case\_simple}}{}%
 }}
 

--- a/doc/tyeq.ott
+++ b/doc/tyeq.ott
@@ -184,7 +184,7 @@ G |- a <= A [a1/x][refl/y]
 G |- subst a by y <= A
 
 
-G |- a : A
+G |- a => A
 whnf G |-  A ~> (a1 = a2)
 whnf G |-  a1 ~> True
 whnf G |-  a2 ~> False


### PR DESCRIPTION
Hello Prof. Weirich,

Here are final few change suggestions.
I found the `C-CASE-SIMPLE` rule a difficult to read, here https://github.com/sweirich/pi-forall/commit/78bacf950e9d9ead91e21bcbdca1585278038cb6 is the suggestion for improvement, I'm not sure if it better.
Can you take a look at the changes?

Kind Regards,
Melwyn Saldanha